### PR TITLE
Seamless Spotify token refresh (v1.3.0)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -30,7 +30,7 @@ import KeyCalculator from './utils/KeyCalculator';
 import SpotifyPlayer from 'react-spotify-web-playback';
 
 // Utils
-import { getHashParams } from './utils/utils';
+import { getHashParams, saveSpotifyHashParams } from './utils/utils';
 
 // Assets
 import { ReactComponent as SpotifyLogo } from '../src/assets/login/spotify.svg';
@@ -47,6 +47,14 @@ let spotifyLoginEndpoint = isProduction
 let soundcloudLoginEndpoint = isProduction
   ? 'https://key-track2.herokuapp.com/soundcloud/login'
   : 'http://localhost:8888/soundcloud/login';
+
+let refreshTokenEndpoint = isProduction
+  ? 'https://key-track2.herokuapp.com/refresh_token'
+  : 'http://localhost:8888/refresh_token';
+
+// Refresh the access token this many ms before it actually expires, so API
+// calls never hit a window where the token is dead.
+const REFRESH_LEAD_MS = 5 * 60 * 1000;
 
 class App extends React.Component {
   constructor(props) {
@@ -84,19 +92,25 @@ class App extends React.Component {
     this.getUserPlaylists = this.getUserPlaylists.bind(this);
     this.openKeyCalculator = this.openKeyCalculator.bind(this);
     this.updatePlayer = this.updatePlayer.bind(this);
+    this.refreshAccessToken = this.refreshAccessToken.bind(this);
+    this.scheduleTokenRefresh = this.scheduleTokenRefresh.bind(this);
 
     if (spotifyParams.access_token) {
       spotifyWebApi.setAccessToken(spotifyParams.access_token);
 
       Axios.get(
         `https://api.spotify.com/v1/me?access_token=${spotifyParams.access_token}`
-      ).then((user) => {
-        this.setState({
-          user_id: user.data.id,
-          access_token: spotifyParams.access_token,
-          user_name: user.data.display_name,
-        });
-      });
+      )
+        .then((user) => {
+          this.setState({
+            user_id: user.data.id,
+            access_token: spotifyParams.access_token,
+            user_name: user.data.display_name,
+          });
+        })
+        // A stale token here is expected on reload; componentDidMount will
+        // refresh it and re-bootstrap the user, so swallow the 401 quietly.
+        .catch(() => {});
     } else {
       console.error(
         'Could not get a spotify access token. Received spotify params from server: ',
@@ -124,11 +138,80 @@ class App extends React.Component {
 
   componentDidMount() {
     if (this.state.spotify.loggedIn) {
-      setTimeout(() => {
-        this.setState({
-          showSessionExpiryDialog: true,
+      this.scheduleTokenRefresh();
+    }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.refreshTimer);
+  }
+
+  // Schedule a background token refresh shortly before the current token
+  // expires. Re-arms itself after every refresh so the session stays alive
+  // indefinitely without the user ever logging in again.
+  scheduleTokenRefresh() {
+    const params = getHashParams('spotify', isProduction);
+    const expiresAt = params.expires_at;
+
+    clearTimeout(this.refreshTimer);
+
+    // No expiry recorded (e.g. a session from before this feature shipped) or
+    // already within the lead window: refresh right now.
+    if (!expiresAt || expiresAt - Date.now() <= REFRESH_LEAD_MS) {
+      this.refreshAccessToken();
+      return;
+    }
+
+    this.refreshTimer = setTimeout(
+      this.refreshAccessToken,
+      expiresAt - Date.now() - REFRESH_LEAD_MS
+    );
+  }
+
+  // Exchange the stored refresh token for a fresh access token, update the
+  // Spotify client, player, and persisted credentials, then reschedule.
+  async refreshAccessToken() {
+    const params = getHashParams('spotify', isProduction);
+    if (!params.refresh_token) {
+      return;
+    }
+
+    try {
+      const { data } = await Axios.get(refreshTokenEndpoint, {
+        params: { refresh_token: params.refresh_token },
+      });
+
+      const access_token = data.access_token;
+      const expires_in = data.expires_in || 3600;
+      const updated = {
+        access_token,
+        // Spotify may rotate the refresh token; keep the old one otherwise.
+        refresh_token: data.refresh_token || params.refresh_token,
+        expires_at: Date.now() + expires_in * 1000,
+      };
+      saveSpotifyHashParams(updated);
+
+      spotifyWebApi.setAccessToken(access_token);
+      this.setState({ access_token, showSessionExpiryDialog: false });
+
+      // Ensure the user is bootstrapped — covers the case where the initial
+      // load happened with an already-expired token.
+      if (!this.state.user_id) {
+        const user = await Axios.get('https://api.spotify.com/v1/me', {
+          headers: { Authorization: `Bearer ${access_token}` },
         });
-      }, 3600 * 1000);
+        this.setState({
+          user_id: user.data.id,
+          user_name: user.data.display_name,
+        });
+      }
+
+      this.scheduleTokenRefresh();
+    } catch (error) {
+      // The refresh token itself was rejected (e.g. revoked). This is the only
+      // case where the user genuinely needs to log in again.
+      console.error('Spotify token refresh failed', error);
+      this.setState({ showSessionExpiryDialog: true });
     }
   }
 
@@ -401,8 +484,8 @@ class App extends React.Component {
         <Dialog maxWidth='md' open={this.state.showSessionExpiryDialog}>
           <DialogTitle>Oops!</DialogTitle>
           <DialogContent>
-            Your Spotify session has expired. You can refresh your session for
-            another hour by logging in again.
+            We couldn't automatically refresh your Spotify session. Please log
+            in again to continue.
           </DialogContent>
           <DialogActions>
             <Button onClick={this.handleLogout.bind(this)} variant='outlined'>

--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,19 @@
 const changelog = [
   {
+    version: "1.3.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "Spotify sessions now refresh automatically in the background — no more hourly 'session expired' interruptions or forced re-logins.",
+      },
+      {
+        type: "bugfix",
+        desc: "Wired up the previously-unused token refresh flow: access tokens renew ~5 minutes before expiry and on app load if stale, and the player keeps working seamlessly across refreshes.",
+      },
+    ],
+  },
+  {
     version: "1.2.0",
     date: "11/15/25",
     changes: [

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -2,7 +2,10 @@ import Axios from 'axios';
 
 type HashParams = {
   access_token: string,
-  refresh_token: string
+  refresh_token: string,
+  // Absolute epoch-ms timestamp at which access_token expires. Derived from
+  // Spotify's expires_in (seconds) so the app can refresh proactively.
+  expires_at?: number
 }
 
 export function getHashParams(provider: string = 'spotify', isProduction: boolean) {
@@ -29,6 +32,12 @@ export function getHashParams(provider: string = 'spotify', isProduction: boolea
   }
 }
 
+// Persist refreshed Spotify credentials so they survive reloads and feed the
+// next refresh cycle.
+export function saveSpotifyHashParams(hashParams: HashParams) {
+  window.localStorage.setItem('spotify_hash_params', JSON.stringify(hashParams));
+}
+
 function getAndSetSpotifyHashParamsFromUrlLocal() {
   let hashParams: any = {
     access_token: '',
@@ -39,9 +48,11 @@ function getAndSetSpotifyHashParamsFromUrlLocal() {
     r = /([^&;=]+)=?([^&;]*)/g,
     q = window.location.hash.substring(1);
   while ((e = r.exec(q))) {
-    console.log(e[1])
-    console.log(decodeURIComponent(e[2]));
     hashParams[e[1]] = decodeURIComponent(e[2]);
+  }
+
+  if (hashParams.expires_in) {
+    hashParams.expires_at = Date.now() + Number(hashParams.expires_in) * 1000;
   }
 
   document.cookie = `access_token=${hashParams.access_token}`;
@@ -54,10 +65,15 @@ function getAndSetSpotifyHashParamsFromUrlProd(): HashParams {
   var url = new URL(urlString);
   var a_token = new URLSearchParams(url.search).get('access_token') ?? '';
   var r_token = new URLSearchParams(url.search).get('refresh_token') ?? '';
+  var expires_in = new URLSearchParams(url.search).get('expires_in');
 
   document.cookie = `a_token=${a_token}`;
   document.cookie = `r_token=${r_token}`;
-  return { access_token: a_token, refresh_token: r_token };
+  return {
+    access_token: a_token,
+    refresh_token: r_token,
+    expires_at: expires_in ? Date.now() + Number(expires_in) * 1000 : undefined,
+  };
 }
 
 async function getAndSetSoundcloudHashParamsFromUrl(): Promise<HashParams> {

--- a/local-server/index.js
+++ b/local-server/index.js
@@ -112,7 +112,8 @@ app.get('/callback', function (req, res) {
     request.post(authOptions, function (error, response, body) {
       if (!error && response.statusCode === 200) {
         const access_token = body.access_token,
-          refresh_token = body.refresh_token;
+          refresh_token = body.refresh_token,
+          expires_in = body.expires_in;
 
         const options = {
           url: 'https://api.spotify.com/v1/me',
@@ -140,6 +141,7 @@ app.get('/callback', function (req, res) {
             querystring.stringify({
               access_token: access_token,
               refresh_token: refresh_token,
+              expires_in: expires_in,
             })
         );
       } else {
@@ -177,10 +179,20 @@ app.get('/refresh_token', function (req, res) {
 
   request.post(authOptions, function (error, response, body) {
     if (!error && response.statusCode === 200) {
-      const access_token = body.access_token;
+      // Spotify returns a fresh access_token and expires_in (seconds). It may
+      // also return a new refresh_token, which the client should persist.
       res.send({
-        access_token: access_token,
+        access_token: body.access_token,
+        expires_in: body.expires_in,
+        refresh_token: body.refresh_token,
       });
+    } else {
+      // Previously this branch was missing, so a failed refresh (e.g. revoked
+      // token) would hang the request forever. Respond so the client can fall
+      // back to a re-login prompt.
+      res
+        .status(response && response.statusCode ? response.statusCode : 500)
+        .send({ error: 'could_not_refresh_token' });
     }
   });
 });


### PR DESCRIPTION
## What & why

Spotify access tokens expire after 1 hour. Today the app just sets a fixed 1-hour timer that pops a **"session expired — log in again"** dialog, leaving the user with a broken app and a forced re-login. The backend already had a working `/refresh_token` route — it was just **never called**.

This wires that flow end-to-end so sessions renew silently and the user effectively never gets logged out.

## Changes

**Backend (`local-server/index.js`)**
- `/callback` now forwards `expires_in` to the client so it knows the real expiry.
- `/refresh_token` returns `expires_in` and the (possibly rotated) `refresh_token`, and now **responds on failure** instead of hanging forever (the error branch was missing).

**Client**
- `utils.ts`: capture `expires_in` and persist an absolute `expires_at` timestamp; add `saveSpotifyHashParams` helper.
- `App.js`:
  - `scheduleTokenRefresh()` refreshes ~5 min before expiry and re-arms after each refresh.
  - On load, refreshes immediately if the token is stale or has no recorded expiry (covers pre-existing sessions).
  - Updates the Spotify client, player `token`, and localStorage on refresh; re-bootstraps the user if the initial load token was already expired.
  - The expiry dialog is now a **fallback** shown only when a refresh genuinely fails (revoked refresh token).

## Notes
- Version bumped to **1.3.0** with a changelog entry (shown in the app's changelog dialog + version chip).
- `CI=false` is set for the Netlify build, so the pre-existing ESLint warnings don't block; `react-scripts build` passes locally.
- Not testable end-to-end without a live login, but the build compiles and the flow follows Spotify's Authorization Code refresh spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)