### PR TITLE
Harmonic mixing highlighting + Camelot key colors (v1.5.0)

### DIFF
--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,19 @@
 const changelog = [
   {
+    version: "1.5.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "Harmonic mixing: click any track's key to highlight every harmonically compatible track in the playlist (same key, adjacent on the Camelot wheel, or relative major/minor) and dim the rest.",
+      },
+      {
+        type: "feature",
+        desc: "Color-coded keys — each key is now shown as a colored Camelot-wheel chip for faster at-a-glance scanning.",
+      },
+    ],
+  },
+  {
     version: "1.4.0",
     date: "06/09/26",
     changes: [

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -272,6 +272,8 @@ let Playlist = (props) => {
   const [showFilters, setShowFilters] = React.useState(!isMobile); // Collapsed on mobile by default
   let [searchItems, setSearchItems] = React.useState(allItems);
   let [chordProgressions, setChordProgressions] = React.useState({});
+  // Track whose key is "anchored" for harmonic-mixing highlighting (or null).
+  const [harmonicAnchorId, setHarmonicAnchorId] = React.useState(null);
 
   let topRef = React.createRef();
 
@@ -313,6 +315,18 @@ let Playlist = (props) => {
         return null;
       }
     }
+  };
+
+  // Camelot code of the anchored track, derived from its key.
+  const anchorKey = harmonicAnchorId ? getKey(harmonicAnchorId) : null;
+  const harmonicAnchorCamelot = anchorKey
+    ? KeyMap[anchorKey.key].camelot[anchorKey.mode]
+    : null;
+
+  const toggleHarmonicAnchor = (item) => {
+    setHarmonicAnchorId((prev) =>
+      prev === item.track.id ? null : item.track.id
+    );
   };
 
   useEffect(() => {
@@ -763,11 +777,34 @@ let Playlist = (props) => {
           </Collapse>
         </AppBar>
 
-        <div style={{ 
-          paddingBottom: isMobile ? "180px" : "63px", 
+        <div style={{
+          paddingBottom: isMobile ? "180px" : "63px",
           overflowX: isMobile ? "auto" : "visible",
           overflowY: "visible"
         }}>
+          {harmonicAnchorCamelot && (
+            <Box
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                padding: "10px 16px",
+                backgroundColor: "#f0fbf4",
+                borderBottom: "1px solid #cdeed7",
+              }}
+            >
+              <Typography variant="body2" style={{ fontWeight: 600 }}>
+                🎚 Harmonic matches for {harmonicAnchorCamelot} — compatible
+                tracks highlighted, others dimmed
+              </Typography>
+              <Chip
+                size="small"
+                label="Clear"
+                onClick={() => setHarmonicAnchorId(null)}
+                onDelete={() => setHarmonicAnchorId(null)}
+              />
+            </Box>
+          )}
           <Table>
             <TableHead ref={topRef}>
               <TableRow>
@@ -802,16 +839,19 @@ let Playlist = (props) => {
                   return aBPM - bBPM;
                 })
                 .map((item) => (
-                  <Row 
-                    item={item} 
-                    userId={props.userId} 
-                    key={item.track.id} 
-                    db={db} 
-                    chordProgressions={chordProgressions} 
-                    handleRowClick={handleRowClick} 
+                  <Row
+                    item={item}
+                    userId={props.userId}
+                    key={item.track.id}
+                    db={db}
+                    chordProgressions={chordProgressions}
+                    handleRowClick={handleRowClick}
                     getKey={getKey}
                     isMobile={isMobile}
                     isTablet={isTablet}
+                    harmonicAnchorId={harmonicAnchorId}
+                    harmonicAnchorCamelot={harmonicAnchorCamelot}
+                    onToggleAnchor={toggleHarmonicAnchor}
                   />
                 ))}
             </TableBody>

--- a/client/src/components/PLLibrary/Row.jsx
+++ b/client/src/components/PLLibrary/Row.jsx
@@ -20,11 +20,62 @@ import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
 
 import KeyMap from "../../utils/KeyMap";
+import { camelotColor, harmonicRelation } from "../../utils/harmonic";
 
 // TODO: FIX CHORD PROGRESSIONS BUG HERE
 let Row = (props) => {
     const { item } = props;
     const [open, setOpen] = React.useState(false);
+
+    // Key/Camelot info for this track, computed once.
+    const trackKey = props.getKey(item.track.id);
+    const camelot = trackKey ? KeyMap[trackKey.key].camelot[trackKey.mode] : null;
+    const keyColor = camelot ? camelotColor(camelot) : null;
+
+    // Harmonic-mixing highlight relative to the anchored track (if any).
+    const isAnchor = props.harmonicAnchorId === item.track.id;
+    const relation = harmonicRelation(
+      props.harmonicAnchorCamelot,
+      camelot,
+      isAnchor
+    );
+
+    const rowStyle = { cursor: "pointer" };
+    if (relation === "incompatible") rowStyle.opacity = 0.4;
+    if (relation === "compatible")
+      rowStyle.backgroundColor = "rgba(30, 215, 96, 0.12)";
+    if (relation === "anchor") {
+      rowStyle.backgroundColor = "rgba(30, 215, 96, 0.2)";
+      rowStyle.boxShadow = `inset 3px 0 0 ${keyColor ? keyColor.bg : "#1ED760"}`;
+    }
+
+    // A colored, clickable pill for a key value. Clicking anchors this track so
+    // its harmonic matches light up across the table.
+    const keyChip = (label) => (
+      <span
+        onClick={(e) => {
+          e.stopPropagation();
+          if (props.onToggleAnchor) props.onToggleAnchor(item);
+        }}
+        title="Click to highlight harmonic matches"
+        style={
+          keyColor
+            ? {
+                backgroundColor: keyColor.bg,
+                color: keyColor.text,
+                padding: "3px 10px",
+                borderRadius: "12px",
+                fontWeight: 600,
+                cursor: "pointer",
+                display: "inline-block",
+                whiteSpace: "nowrap",
+              }
+            : {}
+        }
+      >
+        {label}
+      </span>
+    );
     const [editChords, setEditChords] = React.useState(false);
     const [oldProgressions, setOldProgressions] = React.useState(
       props.chordProgressions[item.track.id] || {}
@@ -50,7 +101,7 @@ let Row = (props) => {
         <TableRow
           key={item.track.id}
           hover
-          style={{ cursor: "pointer" }}
+          style={rowStyle}
           onClick={(event) => props.handleRowClick(event, item)}
           sx={{ "& > *": { borderBottom: "unset" } }}
         >
@@ -117,12 +168,16 @@ let Row = (props) => {
             </TableCell>
           )}
           <TableCell>
-            {getKey(item.track.id) || getKey(item.track.id) === 0
-              ? `${KeyMap[getKey(item.track.id).key].key}${
-                  props.isMobile 
-                    ? (getKey(item.track.id).mode === 1 ? " Maj" : " Min")
-                    : ""
-                }`
+            {trackKey
+              ? keyChip(
+                  `${KeyMap[trackKey.key].key}${
+                    props.isMobile
+                      ? trackKey.mode === 1
+                        ? " Maj"
+                        : " Min"
+                      : ""
+                  }`
+                )
               : "N/A"}
           </TableCell>
           {!props.isMobile && (
@@ -135,13 +190,7 @@ let Row = (props) => {
             </TableCell>
           )}
           {!props.isTablet && (
-            <TableCell>
-              {getKey(item.track.id) || getKey(item.track.id) === 0
-                ? KeyMap[getKey(item.track.id).key].camelot[
-                    getKey(item.track.id).mode
-                  ]
-                : "N/A"}
-            </TableCell>
+            <TableCell>{camelot ? keyChip(camelot) : "N/A"}</TableCell>
           )}
           {!props.isTablet && (
             <TableCell>

--- a/client/src/utils/harmonic.js
+++ b/client/src/utils/harmonic.js
@@ -1,0 +1,55 @@
+// Harmonic-mixing helpers built around the Camelot wheel.
+//
+// A Camelot code is a number 1-12 plus a letter: "A" = minor, "B" = major.
+// Two tracks mix harmonically when their codes are: identical, ±1 on the same
+// letter (adjacent on the wheel = neighboring keys), or the same number on the
+// opposite letter (relative major/minor). These are the rules DJs use for a
+// clean key transition.
+
+const CAMELOT_RE = /^(\d{1,2})([AB])$/;
+
+function parse(code) {
+  const m = CAMELOT_RE.exec(code || "");
+  if (!m) return null;
+  return { num: parseInt(m[1], 10), letter: m[2] };
+}
+
+// Set of codes that mix harmonically with `code` (includes `code` itself).
+export function compatibleCamelot(code) {
+  const p = parse(code);
+  if (!p) return new Set();
+
+  const up = (p.num % 12) + 1; // 12 wraps to 1
+  const down = ((p.num + 10) % 12) + 1; // 1 wraps to 12
+  const other = p.letter === "A" ? "B" : "A";
+
+  return new Set([
+    `${p.num}${p.letter}`, // same key
+    `${up}${p.letter}`, // +1 (perfect fifth)
+    `${down}${p.letter}`, // -1 (perfect fourth)
+    `${p.num}${other}`, // relative major/minor
+  ]);
+}
+
+// Camelot-wheel color for a code. Each number maps to a distinct hue around the
+// wheel; minor (A) is rendered darker and major (B) lighter, mirroring how
+// Mixed In Key / Rekordbox color keys. Returns { bg, text } for styling a chip.
+export function camelotColor(code) {
+  const p = parse(code);
+  if (!p) return null;
+
+  const hue = ((p.num - 1) * 30) % 360; // 12 keys evenly around the color wheel
+  const lightness = p.letter === "B" ? 64 : 48;
+  const bg = `hsl(${hue}, 68%, ${lightness}%)`;
+  const text = lightness >= 58 ? "#1a1a1a" : "#ffffff";
+
+  return { bg, text };
+}
+
+// Relationship of `code` to the currently anchored key, used to highlight rows.
+// `isAnchor` distinguishes the clicked track from other tracks in the same key.
+export function harmonicRelation(anchorCode, code, isAnchor) {
+  if (!anchorCode) return "none";
+  if (isAnchor) return "anchor";
+  return compatibleCamelot(anchorCode).has(code) ? "compatible" : "incompatible";
+}


### PR DESCRIPTION
## What & why

The core feature DJs reach for: **harmonic mixing**. This makes KeyTrack tell you, at a glance, which tracks in a playlist will mix cleanly together — plus colors every key the way DJ software does for fast scanning.

## Features

**1. Color-coded keys**
Every key now renders as a colored chip. Colors follow the Camelot wheel (each number = a distinct hue; minor/A darker, major/B lighter), mirroring Mixed In Key / Rekordbox so it's instantly familiar. Applied to both the Musical Key and Camelot Key columns.

**2. Harmonic-match highlighting**
Click any track's key chip to **anchor** it. The table then:
- **Highlights** harmonically compatible tracks (same key, ±1 on the wheel, or relative major/minor),
- marks the **anchor** with a colored bar,
- **dims** incompatible tracks,
- shows a banner with the anchored key and a **Clear** button.

Click the same key again (or Clear) to reset.

## Implementation
- New `client/src/utils/harmonic.js`: `compatibleCamelot(code)`, `camelotColor(code)`, `harmonicRelation(...)` — pure functions, fully client-side, no API calls.
- `Row.jsx`: computes its Camelot code + color once, renders clickable key chips, applies the row highlight based on its relation to the anchor.
- `Playlist.jsx`: holds the `harmonicAnchorId`, derives the anchor's Camelot code, passes anchor props to each `Row`, and renders the banner.

## Notes
- Pure UI/logic on key data already fetched — no new Spotify calls, no deprecation exposure.
- Anchor chips live in the Musical Key column (always visible) and Camelot column (desktop), so the feature works across breakpoints.
- Version bumped to **1.5.0** + changelog entry. Build passes locally.

## Screenshot
_(Harmonic highlighting in action — anchor a key and watch compatible tracks light up.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)