### PR TITLE
Local dev setup: dotenv credentials + 127.0.0.1 login fix (v1.5.1)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -41,11 +41,11 @@ let isProduction = process.env.NODE_ENV === 'production';
 
 let spotifyLoginEndpoint = isProduction
   ? 'https://key-track2.herokuapp.com/spotify/login'
-  : 'http://localhost:8888/spotify/login';
+  : 'http://127.0.0.1:8888/spotify/login';
 
 let refreshTokenEndpoint = isProduction
   ? 'https://key-track2.herokuapp.com/refresh_token'
-  : 'http://localhost:8888/refresh_token';
+  : 'http://127.0.0.1:8888/refresh_token';
 
 // Refresh the access token this many ms before it actually expires, so API
 // calls never hit a window where the token is dead.

--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,19 @@
 const changelog = [
   {
+    version: "1.5.1",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "bugfix",
+        desc: "Fixed local-development Spotify login — Spotify now rejects http://localhost as an insecure redirect URI, so local auth uses the 127.0.0.1 loopback address.",
+      },
+      {
+        type: "bugfix",
+        desc: "Developer experience: the local backend now loads Spotify credentials from a gitignored .env file, so they no longer need to be passed on every start.",
+      },
+    ],
+  },
+  {
     version: "1.5.0",
     date: "06/09/26",
     changes: [

--- a/local-server/.env.example
+++ b/local-server/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to `.env` and fill in your Spotify app credentials.
+# The backend loads `.env` automatically (via dotenv) on every start, so you
+# only set these once for local development.
+#
+# Get these from your Spotify app at https://developer.spotify.com/dashboard
+# and make sure http://localhost:8888/callback is added as a Redirect URI.
+
+SPOTIFY_ID=your_spotify_client_id
+SPOTIFY_SECRET=your_spotify_client_secret

--- a/local-server/.gitignore
+++ b/local-server/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.env

--- a/local-server/index.js
+++ b/local-server/index.js
@@ -7,6 +7,10 @@
  * https://developer.spotify.com/web-api/authorization-guide/#authorization_code_flow
  */
 
+// Load local dev credentials from local-server/.env if present. On Heroku the
+// real env vars are already set, so this is a harmless no-op there.
+require('dotenv').config();
+
 const express = require('express'); // Express web server framework
 const request = require('request'); // "Request" library
 const cors = require('cors');
@@ -19,7 +23,9 @@ const spotify_client_secret = process.env.SPOTIFY_SECRET; // Your secret
 const isProduction = process.env.NODE_ENV === 'production';
 const redirect_uri = isProduction
   ? 'https://key-track2.herokuapp.com/callback/'
-  : 'http://localhost:8888/callback';
+  // Spotify rejects http://localhost as an "Insecure" redirect URI; the
+  // explicit loopback IP is required for local development.
+  : 'http://127.0.0.1:8888/callback';
 
 /**
  * Generates a random string containing numbers and letters,

--- a/local-server/index.js
+++ b/local-server/index.js
@@ -7,9 +7,10 @@
  * https://developer.spotify.com/web-api/authorization-guide/#authorization_code_flow
  */
 
-// Load local dev credentials from local-server/.env if present. On Heroku the
-// real env vars are already set, so this is a harmless no-op there.
-require('dotenv').config();
+// Load local dev credentials from local-server/.env if present. Resolve the
+// path from __dirname so it works no matter which directory node is started
+// from. On Heroku the real env vars are already set, so this is a no-op there.
+require('dotenv').config({ path: require('path').join(__dirname, '.env') });
 
 const express = require('express'); // Express web server framework
 const request = require('request'); // "Request" library

--- a/local-server/package-lock.json
+++ b/local-server/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "cookie-parser": "1.3.2",
         "cors": "^2.8.4",
+        "dotenv": "^17.4.2",
         "express": "~4.16.0",
         "node-localstorage": "2.1.6",
         "querystring": "~0.2.0",
@@ -269,6 +270,18 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -1209,6 +1222,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/local-server/package.json
+++ b/local-server/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "cookie-parser": "1.3.2",
     "cors": "^2.8.4",
+    "dotenv": "^17.4.2",
     "express": "~4.16.0",
     "node-localstorage": "2.1.6",
     "querystring": "~0.2.0",


### PR DESCRIPTION
## What & why

Two fixes that make local development actually work, discovered while testing locally.

**1. Spotify login was broken locally — `http://localhost` is rejected as an insecure redirect URI.**
Spotify now requires the explicit loopback IP. The local OAuth flow now uses `http://127.0.0.1:8888` instead of `http://localhost:8888`:
- backend `redirect_uri`
- frontend `spotifyLoginEndpoint` and `refreshTokenEndpoint`

Production URLs are unchanged. (After this, `http://127.0.0.1:8888/callback` must be registered in the Spotify app's Redirect URIs for local login.)

**2. dotenv for credentials.**
The backend read `SPOTIFY_ID`/`SPOTIFY_SECRET` from the environment with no `.env` support, so they had to be exported on every run. Now `local-server` loads a gitignored `local-server/.env` automatically via `dotenv`:
- `require('dotenv').config()` at the top of `index.js` (harmless no-op on Heroku, where real env vars are already set)
- `.env` added to `local-server/.gitignore` (secrets never committed)
- committed `local-server/.env.example` template

## Local setup (for the README later)
```
cp local-server/.env.example local-server/.env   # then fill in SPOTIFY_ID / SPOTIFY_SECRET
```
Register `http://127.0.0.1:8888/callback` as a Redirect URI in the Spotify dashboard.

## Notes
- No user-facing app behavior changes in production; this is dev tooling + a local-auth bugfix. Version bumped to **1.5.1** with a changelog entry.
- `client/package.json` (a pre-existing unrelated working-tree change) is intentionally not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)