### PR TITLE
Memoize playlist rows for snappier large crates (v1.7.1)

### DIFF
--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.7.1",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "bugfix",
+        desc: "Performance: playlist rows are now memoized, so the big track table no longer re-renders when unrelated things change (e.g. opening a dialog) — the app feels snappier on large crates.",
+      },
+    ],
+  },
+  {
     version: "1.7.0",
     date: "06/09/26",
     changes: [

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -294,40 +294,45 @@ let Playlist = (props) => {
     setSearch(String(event.target.value).toLowerCase());
   }, 500);
 
-  let handleRowClick = (event, item) => {
-    let uri = item.track.uri;
-    // Call the parent's updatePlayer function
-    if (props.updatePlayer) {
-      props.updatePlayer([uri], true);
-    }
-  };
+  // useCallback so Row (memoized) keeps a stable reference and doesn't
+  // re-render every time Playlist re-renders for unrelated reasons.
+  const handleRowClick = React.useCallback(
+    (event, item) => {
+      let uri = item.track.uri;
+      if (props.updatePlayer) {
+        props.updatePlayer([uri], true);
+      }
+    },
+    [props.updatePlayer]
+  );
 
   const db = getFirestore();
 
   const spotifyWebApi = new Spotify();
   spotifyWebApi.setAccessToken(props.token);
 
-  let getKey = (id) => {
-    if (id) {
-      let result = props.playlistKeys.find((track) => {
-        if (track) {
-          return id.localeCompare(track.id) === 0;
+  const getKey = React.useCallback(
+    (id) => {
+      if (id) {
+        let result = props.playlistKeys.find((track) => {
+          if (track) {
+            return id.localeCompare(track.id) === 0;
+          }
+          return null;
+        });
+
+        if (result) {
+          return {
+            key: result.key,
+            mode: result.mode,
+            bpm: result.tempo,
+          };
         }
         return null;
-      });
-
-      if (result) {
-        let returnObj = {
-          key: result.key,
-          mode: result.mode,
-          bpm: result.tempo,
-        };
-        return returnObj;
-      } else {
-        return null;
       }
-    }
-  };
+    },
+    [props.playlistKeys]
+  );
 
   // Camelot code of the anchored track, derived from its key.
   const anchorKey = harmonicAnchorId ? getKey(harmonicAnchorId) : null;
@@ -335,11 +340,11 @@ let Playlist = (props) => {
     ? KeyMap[anchorKey.key].camelot[anchorKey.mode]
     : null;
 
-  const toggleHarmonicAnchor = (item) => {
+  const toggleHarmonicAnchor = React.useCallback((item) => {
     setHarmonicAnchorId((prev) =>
       prev === item.track.id ? null : item.track.id
     );
-  };
+  }, []);
 
   useEffect(() => {
     let getChordProgressions = async () => {

--- a/client/src/components/PLLibrary/Row.jsx
+++ b/client/src/components/PLLibrary/Row.jsx
@@ -360,4 +360,7 @@ let Row = (props) => {
     );
   }
 
-  export default Row;
+  // Memoized so rows skip re-rendering when Playlist re-renders without their
+  // props changing (e.g. when an unrelated app-level dialog opens). Rows still
+  // re-render when the anchor, notation, or chord data they depend on changes.
+  export default React.memo(Row);


### PR DESCRIPTION
## What & why

On a large crate, every app-level state change (opening a dialog, toggling the drawer, etc.) re-rendered the entire track table — hundreds of `Row`s each doing key/harmonic work. That's a big part of the "laggy" feel, including the Key-Calculator-over-a-crate pause.

## Changes
- `Row` is now wrapped in `React.memo`.
- The props `Playlist` passes to each `Row` are stabilized with `useCallback` (`handleRowClick`, `getKey`, `toggleHarmonicAnchor`) so the memo actually holds.

Rows still re-render when the things they depend on change — the harmonic anchor, the notation, or loaded chord data — so behavior is unchanged; only wasted re-renders are skipped.

## Testing
Open a large playlist, then open/close the Key Calculator or the menu drawer — the table no longer re-renders underneath. Version bumped to **1.7.1**; build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)