### PR TITLE
Set Builder: ordered sets with key + BPM transition validation (v1.8.0)

### DIFF
--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,19 @@
 const changelog = [
   {
+    version: "1.8.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "Set Builder: add tracks to an ordered set with the + on each row, then reorder them (drag on desktop, up/down on mobile). Each transition is checked for harmonic key compatibility and BPM jump, with clashes flagged.",
+      },
+      {
+        type: "feature",
+        desc: "Set Builder lets you set the BPM-jump threshold that counts as a rough transition, and shows a running count of clashes.",
+      },
+    ],
+  },
+  {
     version: "1.7.1",
     date: "06/09/26",
     changes: [

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -29,7 +29,7 @@ import {
 } from "@material-ui/core";
 
 import { useTheme } from "@material-ui/core/styles";
-import { ArrowUpward, Close, Search, Delete, DonutLarge, FilterList, ExpandMore, ExpandLess } from "@material-ui/icons";
+import { ArrowUpward, Close, Search, Delete, DonutLarge, FilterList, ExpandMore, ExpandLess, QueueMusic } from "@material-ui/icons";
 import Spotify from "spotify-web-api-js";
 
 import { initializeApp } from "firebase/app";
@@ -42,6 +42,7 @@ import { useEffect } from "react";
 import Row from "./Row";
 import Recommendations from "./Recommendations";
 import KeyFilterPicker from "./KeyFilterPicker";
+import SetBuilder from "./SetBuilder";
 
 initializeApp(firebaseConfig);
 
@@ -286,6 +287,35 @@ let Playlist = (props) => {
       prev.includes(code) ? prev.filter((c) => c !== code) : [...prev, code]
     );
   };
+
+  // --- Set builder ---
+  const [setTracks, setSetTracks] = React.useState([]);
+  const [setOpen, setSetOpen] = React.useState(false);
+  const [bpmThreshold, setBpmThreshold] = React.useState(6);
+
+  const addToSet = React.useCallback((item) => {
+    setSetTracks((prev) =>
+      prev.some((t) => t.track.id === item.track.id) ? prev : [...prev, item]
+    );
+    setSetOpen(true);
+  }, []);
+
+  const removeFromSet = React.useCallback(
+    (index) => setSetTracks((prev) => prev.filter((_, i) => i !== index)),
+    []
+  );
+
+  const reorderSet = React.useCallback((from, to) => {
+    setSetTracks((prev) => {
+      if (to < 0 || to >= prev.length) return prev;
+      const next = [...prev];
+      const [moved] = next.splice(from, 1);
+      next.splice(to, 0, moved);
+      return next;
+    });
+  }, []);
+
+  const clearSet = React.useCallback(() => setSetTracks([]), []);
 
   let topRef = React.createRef();
 
@@ -587,6 +617,22 @@ let Playlist = (props) => {
                   Filter by Key{keyFilter.length ? ` (${keyFilter.length})` : ""}
                 </Button>
               </FormControl>
+              <FormControl className={classes.filter}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={<QueueMusic />}
+                  onClick={() => setSetOpen(true)}
+                  style={{
+                    height: "100%",
+                    textTransform: "none",
+                    color: "#fff",
+                    borderColor: "rgba(255,255,255,0.6)",
+                  }}
+                >
+                  Set{setTracks.length ? ` (${setTracks.length})` : ""}
+                </Button>
+              </FormControl>
               <FormControl className={classes.minFilter}>
                 <InputLabel id="demo-simple-select-label">BPM: </InputLabel>
               </FormControl>
@@ -710,6 +756,7 @@ let Playlist = (props) => {
                     harmonicAnchorId={harmonicAnchorId}
                     harmonicAnchorCamelot={harmonicAnchorCamelot}
                     onToggleAnchor={toggleHarmonicAnchor}
+                    onAddToSet={addToSet}
                   />
                 ))}
             </TableBody>
@@ -757,6 +804,19 @@ let Playlist = (props) => {
           onClear={() => setKeyFilter([])}
           filterMode={filterMode}
           onChangeFilterMode={changeFilterMode}
+        />
+
+        <SetBuilder
+          open={setOpen}
+          onClose={() => setSetOpen(false)}
+          set={setTracks}
+          getKey={getKey}
+          onReorder={reorderSet}
+          onRemove={removeFromSet}
+          onClear={clearSet}
+          bpmThreshold={bpmThreshold}
+          onChangeBpmThreshold={setBpmThreshold}
+          isMobile={isMobile}
         />
       </Dialog>
     </div>

--- a/client/src/components/PLLibrary/Row.jsx
+++ b/client/src/components/PLLibrary/Row.jsx
@@ -18,6 +18,7 @@ import {
 
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
+import PlaylistAddIcon from "@material-ui/icons/PlaylistAdd";
 
 import KeyMap from "../../utils/KeyMap";
 import { camelotColor, harmonicRelation } from "../../utils/harmonic";
@@ -91,6 +92,20 @@ let Row = (props) => {
         {label}
       </span>
     );
+    const addButton = (
+      <IconButton
+        aria-label="add to set"
+        size="small"
+        title="Add to set"
+        onClick={(e) => {
+          e.stopPropagation();
+          if (props.onAddToSet) props.onAddToSet(item);
+        }}
+      >
+        <PlaylistAddIcon fontSize="small" />
+      </IconButton>
+    );
+
     const [editChords, setEditChords] = React.useState(false);
     const [oldProgressions, setOldProgressions] = React.useState(
       props.chordProgressions[item.track.id] || {}
@@ -122,16 +137,19 @@ let Row = (props) => {
         >
           {!props.isMobile && (
             <TableCell>
-              <IconButton
-                aria-label="expand row"
-                size="small"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setOpen(!open);
-                }}
-              >
-                {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-              </IconButton>
+              <div style={{ display: "flex", alignItems: "center" }}>
+                <IconButton
+                  aria-label="expand row"
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setOpen(!open);
+                  }}
+                >
+                  {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+                </IconButton>
+                {addButton}
+              </div>
             </TableCell>
           )}
           {!props.isMobile && (
@@ -168,6 +186,7 @@ let Row = (props) => {
                 >
                   {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
                 </IconButton>
+                {addButton}
               </div>
             )}
             <div style={{ fontWeight: 'bold' }}>{item.track.name}</div>

--- a/client/src/components/PLLibrary/SetBuilder.jsx
+++ b/client/src/components/PLLibrary/SetBuilder.jsx
@@ -1,0 +1,284 @@
+import React from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  Drawer,
+  IconButton,
+  Slider,
+  Typography,
+} from "@material-ui/core";
+import {
+  ArrowUpward,
+  ArrowDownward,
+  Close,
+  Delete,
+  DragIndicator,
+} from "@material-ui/icons";
+
+import KeyMap from "../../utils/KeyMap";
+import { camelotColor, compatibleCamelot } from "../../utils/harmonic";
+
+const codeOf = (k) => (k ? KeyMap[k.key].camelot[k.mode] : null);
+
+// The ordered set, shown in a slide-out panel (bottom sheet on mobile, right
+// drawer on desktop). Each transition between consecutive tracks is validated
+// for harmonic key compatibility and BPM jump (vs a user-set threshold).
+const SetBuilder = ({
+  open,
+  onClose,
+  set,
+  getKey,
+  onReorder,
+  onRemove,
+  onClear,
+  bpmThreshold,
+  onChangeBpmThreshold,
+  isMobile,
+}) => {
+  const [dragIndex, setDragIndex] = React.useState(null);
+
+  const rows = set.map((item) => {
+    const k = getKey(item.track.id);
+    return { item, code: codeOf(k), bpm: k ? Math.round(k.bpm) : null };
+  });
+
+  const transition = (a, b) => {
+    if (!a.code || !b.code || a.bpm == null || b.bpm == null) return null;
+    const keyCompatible = compatibleCamelot(a.code).has(b.code);
+    const sameKey = a.code === b.code;
+    const bpmDelta = b.bpm - a.bpm;
+    const bpmPct = a.bpm ? (Math.abs(bpmDelta) / a.bpm) * 100 : 0;
+    const bpmClash = bpmPct > bpmThreshold;
+    return {
+      keyCompatible,
+      sameKey,
+      bpmDelta,
+      bpmPct,
+      bpmClash,
+      clash: !keyCompatible || bpmClash,
+    };
+  };
+
+  const clashCount = rows.reduce((n, r, i) => {
+    if (i === 0) return n;
+    const t = transition(rows[i - 1], r);
+    return n + (t && t.clash ? 1 : 0);
+  }, 0);
+
+  const handleDrop = (to) => {
+    if (dragIndex !== null && dragIndex !== to) onReorder(dragIndex, to);
+    setDragIndex(null);
+  };
+
+  return (
+    <Drawer
+      anchor={isMobile ? "bottom" : "right"}
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        style: {
+          width: isMobile ? "100%" : 380,
+          maxWidth: "100%",
+          maxHeight: isMobile ? "85vh" : "100%",
+          borderTopLeftRadius: isMobile ? 16 : 0,
+          borderTopRightRadius: isMobile ? 16 : 0,
+        },
+      }}
+    >
+      <Box
+        style={{
+          padding: 16,
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+        }}
+      >
+        <Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <Typography variant="h6">Your Set ({set.length})</Typography>
+          <IconButton size="small" onClick={onClose} aria-label="close">
+            <Close />
+          </IconButton>
+        </Box>
+
+        <Box style={{ margin: "8px 0 12px" }}>
+          <Typography variant="caption" color="textSecondary">
+            Flag BPM jumps over {bpmThreshold}%
+          </Typography>
+          <Slider
+            value={bpmThreshold}
+            min={1}
+            max={20}
+            step={1}
+            valueLabelDisplay="auto"
+            onChange={(e, v) => onChangeBpmThreshold(v)}
+          />
+        </Box>
+
+        {set.length === 0 ? (
+          <Typography variant="body2" color="textSecondary">
+            Add tracks with the + on each row to start building a set. Transitions
+            are checked for key compatibility and BPM jumps as you go.
+          </Typography>
+        ) : (
+          <>
+            <Typography
+              variant="caption"
+              style={{
+                color: clashCount ? "#c0392b" : "#2e7d32",
+                fontWeight: 600,
+                marginBottom: 6,
+              }}
+            >
+              {clashCount
+                ? `${clashCount} rough transition${clashCount > 1 ? "s" : ""}`
+                : "All transitions smooth ✓"}
+            </Typography>
+
+            <Box style={{ overflowY: "auto", flex: 1 }}>
+              {rows.map((r, i) => (
+                <React.Fragment key={`${r.item.track.id}-${i}`}>
+                  <Box
+                    draggable={!isMobile}
+                    onDragStart={() => setDragIndex(i)}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={() => handleDrop(i)}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      padding: 8,
+                      borderRadius: 8,
+                      border: "1px solid rgba(128,128,128,0.25)",
+                      opacity: dragIndex === i ? 0.5 : 1,
+                    }}
+                  >
+                    {!isMobile && (
+                      <DragIndicator
+                        style={{ cursor: "grab", color: "#999", fontSize: 18 }}
+                      />
+                    )}
+                    <Typography
+                      variant="caption"
+                      style={{ width: 16, color: "#999" }}
+                    >
+                      {i + 1}
+                    </Typography>
+                    {r.code && (
+                      <Chip
+                        size="small"
+                        label={r.code}
+                        style={{
+                          backgroundColor: camelotColor(r.code).bg,
+                          color: camelotColor(r.code).text,
+                        }}
+                      />
+                    )}
+                    <Box style={{ flex: 1, minWidth: 0 }}>
+                      <Typography
+                        variant="body2"
+                        style={{
+                          fontWeight: 600,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {r.item.track.name}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        color="textSecondary"
+                        style={{
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                          display: "block",
+                        }}
+                      >
+                        {r.item.track.artists.map((a) => a.name).join(", ")} ·{" "}
+                        {r.bpm} BPM
+                      </Typography>
+                    </Box>
+                    <IconButton
+                      size="small"
+                      disabled={i === 0}
+                      onClick={() => onReorder(i, i - 1)}
+                      aria-label="move up"
+                    >
+                      <ArrowUpward fontSize="small" />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      disabled={i === rows.length - 1}
+                      onClick={() => onReorder(i, i + 1)}
+                      aria-label="move down"
+                    >
+                      <ArrowDownward fontSize="small" />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      onClick={() => onRemove(i)}
+                      aria-label="remove"
+                    >
+                      <Delete fontSize="small" />
+                    </IconButton>
+                  </Box>
+
+                  {i < rows.length - 1 &&
+                    (() => {
+                      const t = transition(rows[i], rows[i + 1]);
+                      if (!t) return null;
+                      return (
+                        <Box
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 6,
+                            padding: "3px 14px",
+                            fontSize: 12,
+                            color: t.clash ? "#c0392b" : "#2e7d32",
+                          }}
+                        >
+                          <span>{t.clash ? "⚠" : "✓"}</span>
+                          <span>
+                            {t.sameKey
+                              ? "same key"
+                              : t.keyCompatible
+                              ? "key compatible"
+                              : "key clash"}
+                          </span>
+                          <span>
+                            · {t.bpmDelta >= 0 ? "+" : ""}
+                            {t.bpmDelta} BPM ({Math.round(t.bpmPct)}%)
+                            {t.bpmClash ? " ⚠" : ""}
+                          </span>
+                        </Box>
+                      );
+                    })()}
+                </React.Fragment>
+              ))}
+            </Box>
+
+            <Button
+              size="small"
+              startIcon={<Delete />}
+              onClick={onClear}
+              style={{ marginTop: 8, alignSelf: "flex-start" }}
+            >
+              Clear set
+            </Button>
+          </>
+        )}
+      </Box>
+    </Drawer>
+  );
+};
+
+export default SetBuilder;


### PR DESCRIPTION
## What & why

A **Set Builder** for sequencing a DJ set: drag tracks into an order and have the app flag rough transitions (key clashes + big BPM jumps) as you go. No auto-generation — you build it.

> ⚠️ **Stacked on #36** (`perf/memoize-rows`). Merge #36 first; until then this PR's diff also shows the row-memoization change.

## How it works
- A **+** on each playlist row adds the track to your set (and opens the panel).
- The set lives in a **slide-out panel** — a **bottom sheet on mobile**, a **right-side drawer on desktop** — opened by the **Set (N)** button in the filter bar. So it never fights the table for space on a phone.
- **Reorder**: drag on desktop, **up/down buttons** everywhere (mobile-friendly). Remove per-track, or Clear.
- **Transition validation** between each consecutive pair:
  - Harmonic **key compatibility** (Camelot rules: same / adjacent / relative).
  - **BPM delta** vs a **user-set threshold** (slider, default 6%).
  - Clashes flagged inline (⚠) with a running **clash count** / "All transitions smooth ✓".

## Notes
- Reuses `camelotColor` / `compatibleCamelot` and the memoized rows from #36.
- Version → **1.8.0**, changelog updated. Build passes.

## Screenshots
_Set panel with transition badges (desktop):_ _(placeholder)_
_Bottom sheet (mobile):_ _(placeholder)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)