### PR TITLE
Save / load / edit named sets via Firestore (v1.10.0)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -160,6 +160,7 @@ class App extends React.Component {
     this.reorderSet = this.reorderSet.bind(this);
     this.clearSet = this.clearSet.bind(this);
     this.openSet = this.openSet.bind(this);
+    this.loadSet = this.loadSet.bind(this);
     this.updatePlayer = this.updatePlayer.bind(this);
     this.refreshAccessToken = this.refreshAccessToken.bind(this);
     this.scheduleTokenRefresh = this.scheduleTokenRefresh.bind(this);
@@ -346,6 +347,11 @@ class App extends React.Component {
 
   openSet() {
     this.setState({ setOpen: true });
+  }
+
+  // Replace the current set with a loaded saved set.
+  loadSet(entries) {
+    this.setState({ set: entries, setOpen: true });
   }
 
   toggleTheme() {
@@ -852,6 +858,8 @@ class App extends React.Component {
             onReorder={this.reorderSet}
             onRemove={this.removeFromSet}
             onClear={this.clearSet}
+            userId={this.state.user_id}
+            onLoadSet={this.loadSet}
           />
 
           {/* Spotify Player - always visible at bottom */}

--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.10.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "Save, load, update, and delete your sets — name a set and it's stored to your account, so you can pick up a build later. Saved sets keep each track's key/BPM, so loading one doesn't need to refetch from Spotify.",
+      },
+    ],
+  },
+  {
     version: "1.9.0",
     date: "06/09/26",
     changes: [

--- a/client/src/components/PLLibrary/SetBuilder.jsx
+++ b/client/src/components/PLLibrary/SetBuilder.jsx
@@ -3,9 +3,11 @@ import {
   Box,
   Button,
   Chip,
+  Divider,
   Drawer,
   IconButton,
   Slider,
+  TextField,
   Typography,
   useMediaQuery,
 } from "@material-ui/core";
@@ -16,10 +18,18 @@ import {
   Close,
   Delete,
   DragIndicator,
+  Save,
 } from "@material-ui/icons";
 
 import KeyMap from "../../utils/KeyMap";
 import { camelotColor, compatibleCamelot } from "../../utils/harmonic";
+import {
+  fetchSets,
+  saveSet,
+  updateSet,
+  deleteSet,
+  deserializeTracks,
+} from "../../utils/sets";
 
 const codeOf = (k) => (k ? KeyMap[k.key].camelot[k.mode] : null);
 
@@ -27,12 +37,84 @@ const codeOf = (k) => (k ? KeyMap[k.key].camelot[k.mode] : null);
 // drawer on desktop). Each entry is { item, key } so the set is self-contained
 // and can hold tracks from multiple playlists. Each transition between
 // consecutive tracks is validated for harmonic key compatibility and BPM jump.
-const SetBuilder = ({ open, onClose, set, onReorder, onRemove, onClear }) => {
+const SetBuilder = ({
+  open,
+  onClose,
+  set,
+  onReorder,
+  onRemove,
+  onClear,
+  userId,
+  onLoadSet,
+}) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [dragIndex, setDragIndex] = React.useState(null);
   // Local so dragging the slider only re-renders this panel, never the whole app.
   const [bpmThreshold, setBpmThreshold] = React.useState(6);
+
+  // Saved-set persistence (Firestore).
+  const [savedSets, setSavedSets] = React.useState([]);
+  const [setName, setSetName] = React.useState("");
+  const [loadedSetId, setLoadedSetId] = React.useState(null);
+  const [busy, setBusy] = React.useState(false);
+
+  const refreshSaved = React.useCallback(async () => {
+    if (!userId) return;
+    try {
+      setSavedSets(await fetchSets(userId));
+    } catch (e) {
+      console.error("Failed to load saved sets", e);
+    }
+  }, [userId]);
+
+  React.useEffect(() => {
+    if (open) refreshSaved();
+  }, [open, refreshSaved]);
+
+  const handleSave = async (asNew) => {
+    if (!userId || !setName.trim() || set.length === 0) return;
+    setBusy(true);
+    try {
+      if (!asNew && loadedSetId) {
+        await updateSet(userId, loadedSetId, {
+          name: setName.trim(),
+          bpmThreshold,
+          set,
+        });
+      } else {
+        const ref = await saveSet(userId, {
+          name: setName.trim(),
+          bpmThreshold,
+          set,
+        });
+        setLoadedSetId(ref.id);
+      }
+      await refreshSaved();
+    } catch (e) {
+      console.error("Failed to save set", e);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleLoad = (s) => {
+    if (onLoadSet) onLoadSet(deserializeTracks(s.tracks));
+    setLoadedSetId(s.id);
+    setSetName(s.name || "");
+    if (typeof s.bpmThreshold === "number") setBpmThreshold(s.bpmThreshold);
+  };
+
+  const handleDeleteSaved = async (s) => {
+    if (!userId) return;
+    try {
+      await deleteSet(userId, s.id);
+      if (loadedSetId === s.id) setLoadedSetId(null);
+      await refreshSaved();
+    } catch (e) {
+      console.error("Failed to delete set", e);
+    }
+  };
 
   const rows = set.map((entry) => {
     const k = entry.key;
@@ -90,6 +172,7 @@ const SetBuilder = ({ open, onClose, set, onReorder, onRemove, onClear }) => {
           display: "flex",
           flexDirection: "column",
           height: "100%",
+          overflowY: "auto",
         }}
       >
         <Box
@@ -139,7 +222,7 @@ const SetBuilder = ({ open, onClose, set, onReorder, onRemove, onClear }) => {
                 : "All transitions smooth ✓"}
             </Typography>
 
-            <Box style={{ overflowY: "auto", flex: 1 }}>
+            <Box>
               {rows.map((r, i) => (
                 <React.Fragment key={`${r.item.track.id}-${i}`}>
                   <Box
@@ -273,6 +356,102 @@ const SetBuilder = ({ open, onClose, set, onReorder, onRemove, onClear }) => {
               Clear set
             </Button>
           </>
+        )}
+
+        {/* Save the current set */}
+        {set.length > 0 && userId && (
+          <Box style={{ marginTop: 16 }}>
+            <Divider style={{ marginBottom: 12 }} />
+            <Box style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <TextField
+                size="small"
+                variant="outlined"
+                placeholder="Set name"
+                value={setName}
+                onChange={(e) => setSetName(e.target.value)}
+                style={{ flex: 1 }}
+              />
+              {loadedSetId ? (
+                <>
+                  <Button
+                    size="small"
+                    variant="contained"
+                    color="primary"
+                    disabled={busy || !setName.trim()}
+                    onClick={() => handleSave(false)}
+                  >
+                    Update
+                  </Button>
+                  <Button
+                    size="small"
+                    disabled={busy || !setName.trim()}
+                    onClick={() => handleSave(true)}
+                  >
+                    Save new
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  size="small"
+                  variant="contained"
+                  color="primary"
+                  startIcon={<Save />}
+                  disabled={busy || !setName.trim()}
+                  onClick={() => handleSave(true)}
+                >
+                  Save
+                </Button>
+              )}
+            </Box>
+          </Box>
+        )}
+
+        {/* Saved sets */}
+        {userId && savedSets.length > 0 && (
+          <Box style={{ marginTop: 20 }}>
+            <Typography variant="overline" color="textSecondary">
+              Saved sets
+            </Typography>
+            {savedSets.map((s) => (
+              <Box
+                key={s.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "4px 0",
+                }}
+              >
+                <Box style={{ flex: 1, minWidth: 0 }}>
+                  <Typography
+                    variant="body2"
+                    style={{
+                      fontWeight: 600,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {s.name}
+                    {loadedSetId === s.id ? " (loaded)" : ""}
+                  </Typography>
+                  <Typography variant="caption" color="textSecondary">
+                    {(s.tracks || []).length} tracks
+                  </Typography>
+                </Box>
+                <Button size="small" onClick={() => handleLoad(s)}>
+                  Load
+                </Button>
+                <IconButton
+                  size="small"
+                  onClick={() => handleDeleteSaved(s)}
+                  aria-label="delete saved set"
+                >
+                  <Delete fontSize="small" />
+                </IconButton>
+              </Box>
+            ))}
+          </Box>
         )}
       </Box>
     </Drawer>

--- a/client/src/utils/sets.js
+++ b/client/src/utils/sets.js
@@ -1,0 +1,79 @@
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  getDocs,
+  deleteDoc,
+  updateDoc,
+  doc,
+} from "firebase/firestore";
+
+// Saved sets live in Firestore under Users/{spotifyUserId}/sets. Each set
+// stores a self-contained, minimal copy of its tracks (id/uri/name/artists/
+// image + key) so loading a saved set never needs to re-fetch from Spotify.
+//
+// NOTE: the app authenticates with Spotify (not Firebase Auth), so these rely
+// on Firestore's project rules. Tightening them (Firebase Auth + rules) is a
+// separate hardening step.
+
+// SetBuilder entry ({ item, key }) -> compact storable record.
+const serializeEntry = (entry) => {
+  const t = entry.item.track;
+  return {
+    id: t.id || null,
+    uri: t.uri || null,
+    name: t.name || "",
+    artists: (t.artists || []).map((a) => ({ name: a.name })),
+    image: (t.album && t.album.images && t.album.images[0] && t.album.images[0].url) || null,
+    key: entry.key || null,
+  };
+};
+
+// Stored record -> SetBuilder entry, reconstructing the shape the UI expects.
+const deserializeTrack = (s) => ({
+  item: {
+    track: {
+      id: s.id,
+      uri: s.uri,
+      name: s.name,
+      artists: s.artists || [],
+      album: { images: s.image ? [{ url: s.image }] : [] },
+    },
+  },
+  key: s.key || null,
+});
+
+export const deserializeTracks = (tracks) =>
+  (tracks || []).map(deserializeTrack);
+
+const setsCollection = (userId) =>
+  collection(getFirestore(), "Users", userId, "sets");
+
+export async function fetchSets(userId) {
+  const snap = await getDocs(setsCollection(userId));
+  return snap.docs
+    .map((d) => ({ id: d.id, ...d.data() }))
+    .sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+}
+
+export async function saveSet(userId, { name, bpmThreshold, set }) {
+  return addDoc(setsCollection(userId), {
+    name,
+    bpmThreshold,
+    createdAt: Date.now(),
+    tracks: set.map(serializeEntry),
+  });
+}
+
+export async function updateSet(userId, setId, { name, bpmThreshold, set }) {
+  return updateDoc(doc(getFirestore(), "Users", userId, "sets", setId), {
+    name,
+    bpmThreshold,
+    tracks: set.map(serializeEntry),
+    updatedAt: Date.now(),
+  });
+}
+
+export async function deleteSet(userId, setId) {
+  return deleteDoc(doc(getFirestore(), "Users", userId, "sets", setId));
+}


### PR DESCRIPTION
## What & why

You can now **create, save, load, edit, and delete named sets** — so a set survives reloads and you can come back to a build later. Uses the Firestore that's already wired in (no new infra).

## How it works
- In the Set panel: type a **name** and **Save** the current set.
- A **Saved sets** list shows your sets (name + track count) with **Load** and **Delete**.
- Loading a set replaces the current set; the panel then offers **Update** (overwrite that saved set) or **Save new**. The BPM threshold is saved/restored per set.
- Stored under `Users/{spotifyUserId}/sets`, each with a **self-contained** copy of its tracks (id/uri/name/artists/image + key/BPM), so loading a saved set never refetches from Spotify.

## Notes
- New `utils/sets.js` holds the CRUD + (de)serialization; `SetBuilder` gets the UI; `App.loadSet()` swaps the app-level set.
- **Security caveat:** the app authenticates with Spotify, not Firebase Auth, so this relies on the project's Firestore rules (currently open). Tightening (Firebase Auth + rules) is a separate hardening step — flagged, not done here.
- Built on the app-level/cross-playlist set, so saved sets can span playlists too.
- Version → **1.10.0**, changelog updated. Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)