### PR TITLE
Sort + paginate the crate library (v1.12.0)

### DIFF
--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.11.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "Search all crates: load every playlist's tracks into one view and search/filter across your whole library by key, BPM, and text — then add any result straight to your set. (Loads with a progress indicator.)",
+      },
+    ],
+  },
+  {
     version: "1.10.0",
     date: "06/09/26",
     changes: [

--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.12.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "The crate library now sorts (by name, track count, or owner) and paginates, so large libraries render a page at a time instead of all at once.",
+      },
+    ],
+  },
+  {
     version: "1.11.0",
     date: "06/09/26",
     changes: [

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -4,6 +4,7 @@ import _ from "underscore";
 import {
   AppBar,
   Avatar,
+  Button,
   IconButton,
   CircularProgress,
   Dialog,
@@ -180,6 +181,8 @@ let PLLibrary = (props) => {
   
   const [loadingPlaylist, setLoadingPlaylist] = React.useState(false);
   const [loadingId, setLoadingId] = React.useState(null);
+  const [loadingAll, setLoadingAll] = React.useState(false);
+  const [allProgress, setAllProgress] = React.useState({ done: 0, total: 0 });
   const [showPlaylist, setShowPlaylist] = React.useState(false);
   const [currPlaylist, setCurrPlaylist] = React.useState(null);
   const [playlistKeys, setPlaylistKeys] = React.useState(null);
@@ -322,6 +325,94 @@ let PLLibrary = (props) => {
     setShowPlaylist(false);
   };
 
+  // --- Cross-playlist search: load every crate's tracks into one virtual
+  // playlist, then reuse the normal Playlist view to search/filter across them.
+  const fetchAllTracks = async (playlistId) => {
+    let items = [];
+    let offset = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const res = await spotifyWebApi.getPlaylistTracks(playlistId, {
+        offset,
+        limit: 100,
+      });
+      items = items.concat(res.items || []);
+      if (!res.next) break;
+      offset += 100;
+    }
+    return items.filter((it) => it.track && it.track.id);
+  };
+
+  const fetchFeatures = async (ids) => {
+    const out = [];
+    for (let i = 0; i < ids.length; i += 100) {
+      const res = await spotifyWebApi.getAudioFeaturesForTracks(
+        ids.slice(i, i + 100)
+      );
+      out.push(...(res.audio_features || []));
+    }
+    return out;
+  };
+
+  // Concurrency-capped map to avoid bursting the Spotify rate limit.
+  const mapWithLimit = async (items, limit, fn) => {
+    const results = new Array(items.length);
+    let cursor = 0;
+    const worker = async () => {
+      while (cursor < items.length) {
+        const idx = cursor++;
+        results[idx] = await fn(items[idx], idx);
+      }
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(limit, items.length) }, worker)
+    );
+    return results;
+  };
+
+  const handleSearchAllCrates = async () => {
+    const playlists = props.pllibrary || [];
+    if (playlists.length === 0) return;
+
+    setAllProgress({ done: 0, total: playlists.length });
+    setLoadingAll(true);
+    try {
+      const perPlaylist = await mapWithLimit(playlists, 4, async (pl) => {
+        const tracks = await fetchAllTracks(pl.id);
+        const features = await fetchFeatures(tracks.map((t) => t.track.id));
+        setAllProgress((p) => ({ ...p, done: p.done + 1 }));
+        return { tracks, features };
+      });
+
+      // Aggregate + dedupe by track id.
+      const seen = new Set();
+      const allTracks = [];
+      const featById = new Map();
+      perPlaylist.forEach(({ tracks, features }) => {
+        tracks.forEach((item) => {
+          if (!seen.has(item.track.id)) {
+            seen.add(item.track.id);
+            allTracks.push(item);
+          }
+        });
+        features.forEach((f) => {
+          if (f) featById.set(f.id, f);
+        });
+      });
+
+      setPlaylistName(`All Crates · ${allTracks.length} tracks`);
+      setPlaylistId("__all_crates__");
+      setPlaylistOwnerId(null); // hides owner-only Recommendations
+      setCurrPlaylist(allTracks);
+      setPlaylistKeys(Array.from(featById.values()));
+      setShowPlaylist(true);
+    } catch (error) {
+      console.error("Failed to load all crates", error);
+    } finally {
+      setLoadingAll(false);
+    }
+  };
+
   return (
     <>
       <Dialog
@@ -363,8 +454,51 @@ let PLLibrary = (props) => {
               </InputAdornment>
             }
           />
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<Search />}
+            onClick={handleSearchAllCrates}
+            disabled={!props.pllibrary || props.pllibrary.length === 0}
+            style={{
+              color: "#fff",
+              borderColor: "rgba(255,255,255,0.5)",
+              whiteSpace: "nowrap",
+              flexShrink: 0,
+            }}
+          >
+            {isMobile ? "All crates" : "Search all crates"}
+          </Button>
         </Toolbar>
       </AppBar>
+
+      <Dialog
+        open={loadingAll}
+        PaperProps={{
+          style: {
+            padding: "28px 44px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 16,
+            borderRadius: 12,
+          },
+        }}
+      >
+        <CircularProgress
+          classes={{ colorPrimary: classes.colorPrimary }}
+          size={64}
+          variant={allProgress.total ? "determinate" : "indeterminate"}
+          value={
+            allProgress.total
+              ? (allProgress.done / allProgress.total) * 100
+              : 0
+          }
+        />
+        <Typography variant="body1" style={{ fontWeight: 600 }}>
+          Loading all crates… {allProgress.done}/{allProgress.total}
+        </Typography>
+      </Dialog>
 
       <Box sx={{ padding: isMobile ? 1 : 2 }}>
         {searchItems.map((playlist) => (

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -18,6 +18,11 @@ import {
   Typography,
   Box,
   Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TablePagination,
   useMediaQuery,
   useTheme,
 } from "@material-ui/core";
@@ -191,6 +196,35 @@ let PLLibrary = (props) => {
   const [playlistOwnerId, setPlaylistOwnerId] = React.useState("");
   const [search, setSearch] = React.useState("");
   const [searchItems, setSearchItems] = React.useState(props.pllibrary);
+  const [crateSort, setCrateSort] = React.useState("name");
+  const [cratePage, setCratePage] = React.useState(0);
+  const [cratesPerPage, setCratesPerPage] = React.useState(24);
+
+  // Sort + paginate the crate list so we only render a page at a time.
+  const sortedCrates = React.useMemo(() => {
+    const arr = [...(searchItems || [])];
+    arr.sort((a, b) => {
+      if (crateSort === "tracks") {
+        return (b.tracks?.total || 0) - (a.tracks?.total || 0);
+      }
+      if (crateSort === "owner") {
+        return (a.owner?.display_name || "").localeCompare(
+          b.owner?.display_name || ""
+        );
+      }
+      return (a.name || "").localeCompare(b.name || "");
+    });
+    return arr;
+  }, [searchItems, crateSort]);
+
+  const pagedCrates = sortedCrates.slice(
+    cratePage * cratesPerPage,
+    cratePage * cratesPerPage + cratesPerPage
+  );
+
+  React.useEffect(() => {
+    setCratePage(0);
+  }, [searchItems, crateSort, cratesPerPage]);
 
   const spotifyWebApi = new Spotify();
   spotifyWebApi.setAccessToken(props.token);
@@ -500,8 +534,35 @@ let PLLibrary = (props) => {
         </Typography>
       </Dialog>
 
+      <Box
+        sx={{ padding: isMobile ? 1 : 2 }}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 8,
+        }}
+      >
+        <FormControl size="small" style={{ minWidth: 160 }}>
+          <InputLabel>Sort crates by</InputLabel>
+          <Select
+            value={crateSort}
+            label="Sort crates by"
+            onChange={(e) => setCrateSort(e.target.value)}
+          >
+            <MenuItem value="name">Name</MenuItem>
+            <MenuItem value="tracks">Track count</MenuItem>
+            <MenuItem value="owner">Owner</MenuItem>
+          </Select>
+        </FormControl>
+        <Typography variant="caption" color="textSecondary">
+          {sortedCrates.length} crate{sortedCrates.length === 1 ? "" : "s"}
+        </Typography>
+      </Box>
+
       <Box sx={{ padding: isMobile ? 1 : 2 }}>
-        {searchItems.map((playlist) => (
+        {pagedCrates.map((playlist) => (
           <Card
             key={playlist.id}
             className={classes.playlistCard}
@@ -571,6 +632,22 @@ let PLLibrary = (props) => {
           </Card>
         ))}
       </Box>
+
+      {sortedCrates.length > 12 && (
+        <TablePagination
+          component="div"
+          count={sortedCrates.length}
+          page={cratePage}
+          onChangePage={(e, p) => setCratePage(p)}
+          rowsPerPage={cratesPerPage}
+          onChangeRowsPerPage={(e) => {
+            setCratesPerPage(parseInt(e.target.value, 10));
+            setCratePage(0);
+          }}
+          rowsPerPageOptions={[12, 24, 48]}
+          labelRowsPerPage="Crates per page"
+        />
+      )}
 
       {showPlaylist ? (
         <Playlist


### PR DESCRIPTION
## What & why

First of the crate-management batch. The library rendered **every** playlist card at once; now it sorts and paginates so large libraries stay snappy and only render a page at a time.

## Changes
- **Sort** the crate list by **Name / Track count / Owner**.
- **Paginate** the cards (12 / 24 / 48 per page) — only the current page is in the DOM.
- Existing text search still filters; sort + pagination apply on top.

> ⚠️ **Stacked on #40** (cross-playlist search). Merge #40 first; until then this diff also shows #40's changes.

## Next in this batch
2. Favorite / Hide crates (Firestore crate metadata) · 3. Tags + Genres · 4. Search *selected* crates · 5. Liked Songs as a crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)