### PR TITLE
Favorite + hide crates (v1.13.0)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -46,6 +46,7 @@ import {
   Receipt,
   SettingsApplications,
   Tune,
+  VisibilityOff,
 } from '@material-ui/icons';
 import FadeIn from 'react-fade-in';
 
@@ -126,6 +127,7 @@ class App extends React.Component {
       showKeyCalculator: false,
       drawerOpen: false,
       loadingPlaylists: false,
+      showHiddenCrates: false,
       // App-level set so it spans playlists. Entries are { item, key }.
       set: [],
       setOpen: false,
@@ -161,6 +163,8 @@ class App extends React.Component {
     this.clearSet = this.clearSet.bind(this);
     this.openSet = this.openSet.bind(this);
     this.loadSet = this.loadSet.bind(this);
+    this.openHiddenCrates = this.openHiddenCrates.bind(this);
+    this.exitHidden = this.exitHidden.bind(this);
     this.updatePlayer = this.updatePlayer.bind(this);
     this.refreshAccessToken = this.refreshAccessToken.bind(this);
     this.scheduleTokenRefresh = this.scheduleTokenRefresh.bind(this);
@@ -301,6 +305,7 @@ class App extends React.Component {
 
       this.setState({
         showPlaylists: true,
+        showHiddenCrates: false,
         pllibrary: allPlaylists,
       });
     } catch (error) {
@@ -352,6 +357,19 @@ class App extends React.Component {
   // Replace the current set with a loaded saved set.
   loadSet(entries) {
     this.setState({ set: entries, setOpen: true });
+  }
+
+  // Open the library showing only hidden crates (reached from the menu).
+  async openHiddenCrates() {
+    this.setState({ drawerOpen: false });
+    if (!this.state.showPlaylists) {
+      await this.getUserPlaylists();
+    }
+    this.setState({ showHiddenCrates: true });
+  }
+
+  exitHidden() {
+    this.setState({ showHiddenCrates: false });
   }
 
   toggleTheme() {
@@ -618,6 +636,8 @@ class App extends React.Component {
                   onAddToSet={this.addToSet}
                   onOpenSet={this.openSet}
                   setCount={this.state.set.length}
+                  showHidden={this.state.showHiddenCrates}
+                  onExitHidden={this.exitHidden}
                 />
               </FadeIn>
             </Box>
@@ -696,6 +716,12 @@ class App extends React.Component {
                     : 'empty'
                 }
               />
+            </ListItem>
+            <ListItem button onClick={this.openHiddenCrates}>
+              <ListItemIcon>
+                <VisibilityOff />
+              </ListItemIcon>
+              <ListItemText primary="Hidden crates" />
             </ListItem>
             <ListItem>
               <ListItemIcon>

--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.13.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "Favorite crates (★) to pin them to the top of your library, and Hide crates to tuck them away — hidden crates don't appear in the library or in 'Search all crates', and are managed from a new 'Hidden crates' item in the menu.",
+      },
+    ],
+  },
+  {
     version: "1.12.0",
     date: "06/09/26",
     changes: [

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -27,12 +27,20 @@ import {
   useTheme,
 } from "@material-ui/core";
 
-import { MenuOpen, Search, MusicNote } from "@material-ui/icons";
+import {
+  MenuOpen,
+  Search,
+  MusicNote,
+  Star,
+  StarBorder,
+  VisibilityOff,
+} from "@material-ui/icons";
 
 import Spotify from "spotify-web-api-js";
 
 import Playlist from "./Playlist";
 import { useEffect } from "react";
+import { fetchCrateMeta, setCrateMeta } from "../../utils/crateMeta";
 
 const useStyles = makeStyles((theme) => ({
   appBar: {
@@ -199,11 +207,55 @@ let PLLibrary = (props) => {
   const [crateSort, setCrateSort] = React.useState("name");
   const [cratePage, setCratePage] = React.useState(0);
   const [cratesPerPage, setCratesPerPage] = React.useState(24);
+  // Per-user crate metadata { [playlistId]: { favorite, hidden, ... } }.
+  const [crateMeta, setCrateMetaState] = React.useState({});
 
-  // Sort + paginate the crate list so we only render a page at a time.
+  useEffect(() => {
+    if (!props.userId) return;
+    fetchCrateMeta(props.userId)
+      .then(setCrateMetaState)
+      .catch((e) => console.error("Failed to load crate metadata", e));
+  }, [props.userId]);
+
+  const metaFor = (id) => crateMeta[id] || {};
+
+  const updateMeta = (playlist, partial) => {
+    setCrateMetaState((prev) => ({
+      ...prev,
+      [playlist.id]: { ...prev[playlist.id], ...partial },
+    }));
+    if (props.userId) {
+      setCrateMeta(props.userId, playlist.id, partial).catch((e) =>
+        console.error("Failed to save crate metadata", e)
+      );
+    }
+  };
+
+  const toggleFavorite = (e, playlist) => {
+    e.stopPropagation();
+    updateMeta(playlist, { favorite: !metaFor(playlist.id).favorite });
+  };
+
+  const toggleHidden = (e, playlist) => {
+    e.stopPropagation();
+    updateMeta(playlist, { hidden: !metaFor(playlist.id).hidden });
+  };
+
+  // Sort + paginate the crate list so we only render a page at a time. In the
+  // normal view, hidden crates are excluded and favorites are pinned to the top;
+  // the hidden view (from the menu) shows only hidden crates.
+  const showHidden = props.showHidden;
   const sortedCrates = React.useMemo(() => {
-    const arr = [...(searchItems || [])];
+    const arr = (searchItems || []).filter((pl) => {
+      const hidden = !!(crateMeta[pl.id] && crateMeta[pl.id].hidden);
+      return showHidden ? hidden : !hidden;
+    });
     arr.sort((a, b) => {
+      if (!showHidden) {
+        const fa = crateMeta[a.id] && crateMeta[a.id].favorite ? 1 : 0;
+        const fb = crateMeta[b.id] && crateMeta[b.id].favorite ? 1 : 0;
+        if (fa !== fb) return fb - fa; // favorites first
+      }
       if (crateSort === "tracks") {
         return (b.tracks?.total || 0) - (a.tracks?.total || 0);
       }
@@ -215,7 +267,7 @@ let PLLibrary = (props) => {
       return (a.name || "").localeCompare(b.name || "");
     });
     return arr;
-  }, [searchItems, crateSort]);
+  }, [searchItems, crateSort, crateMeta, showHidden]);
 
   const pagedCrates = sortedCrates.slice(
     cratePage * cratesPerPage,
@@ -405,7 +457,10 @@ let PLLibrary = (props) => {
   };
 
   const handleSearchAllCrates = async () => {
-    const playlists = props.pllibrary || [];
+    // Hidden crates are abstracted away — they don't feed the cross-search.
+    const playlists = (props.pllibrary || []).filter(
+      (pl) => !(crateMeta[pl.id] && crateMeta[pl.id].hidden)
+    );
     if (playlists.length === 0) return;
 
     setAllProgress({ done: 0, total: playlists.length });
@@ -561,12 +616,48 @@ let PLLibrary = (props) => {
         </Typography>
       </Box>
 
+      {showHidden && (
+        <Box sx={{ padding: isMobile ? 1 : 2 }} style={{ paddingTop: 0 }}>
+          <Box
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 8,
+            }}
+          >
+            <Typography variant="subtitle2" style={{ fontWeight: 700 }}>
+              Hidden crates
+            </Typography>
+            <Button size="small" onClick={props.onExitHidden}>
+              ← Back to all crates
+            </Button>
+          </Box>
+          <Typography variant="caption" color="textSecondary">
+            Hidden from your library and searches. Un-hide to bring one back.
+          </Typography>
+        </Box>
+      )}
+
+      {sortedCrates.length === 0 && (
+        <Box sx={{ padding: isMobile ? 1 : 2 }}>
+          <Typography variant="body2" color="textSecondary">
+            {showHidden ? "No hidden crates." : "No crates to show."}
+          </Typography>
+        </Box>
+      )}
+
       <Box sx={{ padding: isMobile ? 1 : 2 }}>
         {pagedCrates.map((playlist) => (
           <Card
             key={playlist.id}
             className={classes.playlistCard}
             onClick={() => handlePlaylistOpen(playlist)}
+            style={{
+              borderLeft: metaFor(playlist.id).favorite
+                ? "4px solid #1ED760"
+                : "4px solid transparent",
+            }}
           >
             <CardContent className={classes.cardContent}>
               {/* Album Art */}
@@ -608,26 +699,57 @@ let PLLibrary = (props) => {
                 </Box>
               </Box>
 
-              {/* Open Button / per-card loading spinner */}
-              {loadingId === playlist.id ? (
-                <CircularProgress
-                  classes={{ colorPrimary: classes.colorPrimary }}
-                  size={24}
-                  className={classes.openButton}
-                />
-              ) : (
-                !isMobile && (
-                  <IconButton
-                    className={classes.openButton}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handlePlaylistOpen(playlist);
+              {/* Actions: favorite, hide, open / loading */}
+              <Box
+                style={{ display: "flex", alignItems: "center", flexShrink: 0 }}
+              >
+                <IconButton
+                  size="small"
+                  onClick={(e) => toggleFavorite(e, playlist)}
+                  title={
+                    metaFor(playlist.id).favorite ? "Unfavorite" : "Favorite"
+                  }
+                  aria-label="favorite crate"
+                >
+                  {metaFor(playlist.id).favorite ? (
+                    <Star style={{ color: "#1ED760" }} />
+                  ) : (
+                    <StarBorder />
+                  )}
+                </IconButton>
+                <IconButton
+                  size="small"
+                  onClick={(e) => toggleHidden(e, playlist)}
+                  title={metaFor(playlist.id).hidden ? "Unhide" : "Hide"}
+                  aria-label="hide crate"
+                >
+                  <VisibilityOff
+                    fontSize="small"
+                    style={{
+                      color: metaFor(playlist.id).hidden ? "#1ED760" : undefined,
                     }}
-                  >
-                    <MenuOpen />
-                  </IconButton>
-                )
-              )}
+                  />
+                </IconButton>
+                {loadingId === playlist.id ? (
+                  <CircularProgress
+                    classes={{ colorPrimary: classes.colorPrimary }}
+                    size={24}
+                    style={{ margin: 8 }}
+                  />
+                ) : (
+                  !isMobile && (
+                    <IconButton
+                      className={classes.openButton}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handlePlaylistOpen(playlist);
+                      }}
+                    >
+                      <MenuOpen />
+                    </IconButton>
+                  )
+                )}
+              </Box>
             </CardContent>
           </Card>
         ))}

--- a/client/src/utils/crateMeta.js
+++ b/client/src/utils/crateMeta.js
@@ -1,0 +1,28 @@
+import { getFirestore, collection, getDocs, doc, setDoc } from "firebase/firestore";
+
+// Per-user metadata about crates (playlists), stored under
+// Users/{spotifyUserId}/crateMeta/{playlistId} as { favorite, hidden, tags,
+// genres }. This PR uses favorite + hidden; tags/genres come next and reuse the
+// same docs (writes merge, so fields don't clobber each other).
+//
+// Same security caveat as saved sets: relies on Firestore project rules (the
+// app uses Spotify OAuth, not Firebase Auth).
+
+export async function fetchCrateMeta(userId) {
+  const snap = await getDocs(
+    collection(getFirestore(), "Users", userId, "crateMeta")
+  );
+  const map = {};
+  snap.docs.forEach((d) => {
+    map[d.id] = d.data();
+  });
+  return map; // { [playlistId]: { favorite, hidden, tags, genres } }
+}
+
+export async function setCrateMeta(userId, playlistId, partial) {
+  await setDoc(
+    doc(getFirestore(), "Users", userId, "crateMeta", playlistId),
+    partial,
+    { merge: true }
+  );
+}


### PR DESCRIPTION
## What & why

Batch item #2. Adds the **per-user crate-metadata layer** (Firestore) and uses it for **favoriting** and **hiding** crates. Tags/genres (next) reuse the same docs.

## Features
- **★ Favorite** a crate → pinned to the top of the library with a green accent.
- **Hide** a crate → removed from the library list **and** excluded from "Search all crates."
- A new **"Hidden crates"** item in the menu opens a managed view of hidden crates (with a "← Back to all crates" control) so they stay abstracted away.

## Implementation
- `utils/crateMeta.js`: load/merge-write `Users/{spotifyUserId}/crateMeta/{playlistId}` → `{ favorite, hidden, tags, genres }` (writes merge so later fields don't clobber).
- `PLLibrary`: loads crate meta, favorite/hide toggles per card, favorites-first sort, hidden-filtering for both the list and cross-search, and a `showHidden` mode.
- `App`: `showHiddenCrates` state + bound `openHiddenCrates`/`exitHidden` (kept as bound methods so the memoized `PLLibrary` doesn't re-render — preserves the perf fix).

## Notes
- Same Firestore-rules caveat as saved sets (Spotify OAuth, not Firebase Auth).
- Version → **1.13.0**, changelog updated. Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)