### PR TITLE
Track release date: column, sort & filter (v1.16.0)

### DIFF
--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.16.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "Each track now shows its release month/year, with a new 'Released' column. Sort a playlist by newest/oldest release, and filter by a release-year range.",
+      },
+    ],
+  },
+  {
     version: "1.15.0",
     date: "06/09/26",
     changes: [

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -38,6 +38,7 @@ import { firebaseConfig } from "../../../src/config/firebaseConfig";
 import { doc, getDoc, getFirestore } from "firebase/firestore";
 
 import KeyMap from "../../utils/KeyMap";
+import { releaseSortKey, releaseYear } from "../../utils/release";
 import { useEffect } from "react";
 
 import Row from "./Row";
@@ -261,6 +262,9 @@ let Playlist = (props) => {
   const [keyFilter, setKeyFilter] = React.useState([]);
   const [minBpm, setMinBpm] = React.useState("");
   const [maxBpm, setMaxBpm] = React.useState("");
+  const [minYear, setMinYear] = React.useState("");
+  const [maxYear, setMaxYear] = React.useState("");
+  const [sortBy, setSortBy] = React.useState("key");
   const [showFilters, setShowFilters] = React.useState(!isMobile); // Collapsed on mobile by default
   let [searchItems, setSearchItems] = React.useState(allItems);
   let [chordProgressions, setChordProgressions] = React.useState({});
@@ -366,10 +370,16 @@ let Playlist = (props) => {
   const sortedItems = React.useMemo(() => {
     const arr = [...searchItems];
     arr.sort((a, b) => {
+      if (sortBy === "released-desc" || sortBy === "released-asc") {
+        const diff = releaseSortKey(a.track) - releaseSortKey(b.track);
+        return sortBy === "released-desc" ? -diff : diff;
+      }
       const aKey = getKey(a.track.id);
       const bKey = getKey(b.track.id);
       if (!aKey) return -1;
       if (!bKey) return 1;
+      if (sortBy === "bpm") return aKey.bpm - bKey.bpm;
+      // Default: Camelot key, then BPM.
       const aCamelot = KeyMap[aKey.key].camelot[aKey.mode];
       const bCamelot = KeyMap[bKey.key].camelot[bKey.mode];
       const cmp = aCamelot.localeCompare(bCamelot);
@@ -377,7 +387,7 @@ let Playlist = (props) => {
       return aKey.bpm - bKey.bpm;
     });
     return arr;
-  }, [searchItems, getKey]);
+  }, [searchItems, getKey, sortBy]);
 
   // Only the current page is rendered into the DOM.
   const pagedItems = React.useMemo(
@@ -409,7 +419,9 @@ let Playlist = (props) => {
       keyFilter.length === 0 &&
       search === "" &&
       minBpm === "" &&
-      maxBpm === ""
+      maxBpm === "" &&
+      minYear === "" &&
+      maxYear === ""
     ) {
       _.debounce(setSearchItems(allItems), 500);
     } else {
@@ -458,12 +470,27 @@ let Playlist = (props) => {
               return mappedBpm <= bpmNum;
             });
           }
+
+          if (minYear !== "") {
+            const y = parseInt(minYear, 10);
+            filteredItems = filteredItems.filter((item) => {
+              const ry = releaseYear(item.track);
+              return ry !== null && ry >= y;
+            });
+          }
+          if (maxYear !== "") {
+            const y = parseInt(maxYear, 10);
+            filteredItems = filteredItems.filter((item) => {
+              const ry = releaseYear(item.track);
+              return ry !== null && ry <= y;
+            });
+          }
           return filteredItems;
         }, 500)
       );
     }
     // `wheel` only changes the displayed notation, not which tracks match.
-  }, [search, keyFilter, minBpm, maxBpm]);
+  }, [search, keyFilter, minBpm, maxBpm, minYear, maxYear]);
 
   const handleFilterChange = (event, type) => {
     const {
@@ -476,6 +503,8 @@ let Playlist = (props) => {
       wheel: setWheel,
       minBpm: _.debounce(setMinBpm, 500),
       maxBpm: _.debounce(setMaxBpm, 500),
+      minYear: _.debounce(setMinYear, 500),
+      maxYear: _.debounce(setMaxYear, 500),
     };
 
     funcMap[type](setValue);
@@ -485,8 +514,12 @@ let Playlist = (props) => {
     setKeyFilter([]);
     setMinBpm("");
     setMaxBpm("");
-    document.getElementById("minBpm").value = "";
-    document.getElementById("maxBpm").value = "";
+    setMinYear("");
+    setMaxYear("");
+    ["minBpm", "maxBpm", "minYear", "maxYear"].forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) el.value = "";
+    });
   };
 
   // TODO: Abstract this to new component
@@ -679,6 +712,49 @@ let Playlist = (props) => {
                 />
               </FormControl>
 
+              <FormControl className={classes.minFilter}>
+                <InputLabel id="demo-simple-select-label">Year:</InputLabel>
+              </FormControl>
+              <FormControl className={classes.minFilter}>
+                <InputLabel id="demo-simple-select-label">From</InputLabel>
+                <Input
+                  id="minYear"
+                  type="number"
+                  classes={{ root: classes.root }}
+                  onChange={(e) => handleFilterChange(e, "minYear")}
+                />
+              </FormControl>
+              <FormControl className={classes.toFilter}>
+                <InputLabel id="demo-simple-select-label">to</InputLabel>
+              </FormControl>
+              <FormControl className={classes.maxFilter}>
+                <InputLabel id="demo-simple-select-label">To</InputLabel>
+                <Input
+                  id="maxYear"
+                  type="number"
+                  classes={{ root: classes.root }}
+                  onChange={(e) => handleFilterChange(e, "maxYear")}
+                />
+              </FormControl>
+
+              <FormControl className={classes.filter}>
+                <InputLabel id="demo-simple-select-label">Sort by</InputLabel>
+                <Select
+                  value={sortBy}
+                  label="Sort by"
+                  onChange={(e) => setSortBy(e.target.value)}
+                  inputProps={{
+                    classes: { icon: classes.icon, root: classes.root },
+                  }}
+                  input={<Input />}
+                >
+                  <MenuItem value="key">Key</MenuItem>
+                  <MenuItem value="bpm">BPM</MenuItem>
+                  <MenuItem value="released-desc">Newest</MenuItem>
+                  <MenuItem value="released-asc">Oldest</MenuItem>
+                </Select>
+              </FormControl>
+
               <IconButton
                   aria-label="clear filters"
                   className={classes.button}
@@ -748,6 +824,7 @@ let Playlist = (props) => {
                 </StyledTableCell>
                 {!isMobile && <StyledTableCell>Quality</StyledTableCell>}
                 <StyledTableCell>BPM</StyledTableCell>
+                {!isTablet && <StyledTableCell>Released</StyledTableCell>}
               </TableRow>
             </TableHead>
             <TableBody>

--- a/client/src/components/PLLibrary/Row.jsx
+++ b/client/src/components/PLLibrary/Row.jsx
@@ -194,6 +194,8 @@ let Row = (props) => {
             {props.isMobile && (
               <div style={{ fontSize: '0.875rem', color: '#666', marginTop: '4px' }}>
                 {item.track.artists.map((artist) => artist.name).join(", ")}
+                {" · "}
+                {formatReleaseDate(item.track)}
               </div>
             )}
           </TableCell>

--- a/client/src/components/PLLibrary/Row.jsx
+++ b/client/src/components/PLLibrary/Row.jsx
@@ -22,6 +22,7 @@ import PlaylistAddIcon from "@material-ui/icons/PlaylistAdd";
 
 import KeyMap from "../../utils/KeyMap";
 import { camelotColor, harmonicRelation } from "../../utils/harmonic";
+import { formatReleaseDate } from "../../utils/release";
 
 // TODO: FIX CHORD PROGRESSIONS BUG HERE
 let Row = (props) => {
@@ -214,6 +215,11 @@ let Row = (props) => {
               ? Math.round(getKey(item.track.id).bpm)
               : "N/A"}
           </TableCell>
+          {!props.isTablet && (
+            <TableCell style={{ whiteSpace: "nowrap" }}>
+              {formatReleaseDate(item.track)}
+            </TableCell>
+          )}
         </TableRow>
         <TableRow>
           <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={12}>

--- a/client/src/utils/release.js
+++ b/client/src/utils/release.js
@@ -1,0 +1,35 @@
+// Helpers for a track's release date. Spotify provides album.release_date
+// ("2021", "2021-03", or "2021-03-15") plus release_date_precision.
+
+const MONTHS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+// "Mar 2021" when a month is known, otherwise the year, or "—" if unknown.
+export function formatReleaseDate(track) {
+  const album = track && track.album;
+  const rd = album && album.release_date;
+  if (!rd) return "—";
+  const [y, m] = rd.split("-");
+  if (!m || (album.release_date_precision === "year")) return y;
+  const mi = parseInt(m, 10);
+  return mi >= 1 && mi <= 12 ? `${MONTHS[mi - 1]} ${y}` : y;
+}
+
+export function releaseYear(track) {
+  const rd = track && track.album && track.album.release_date;
+  return rd ? parseInt(rd.slice(0, 4), 10) || null : null;
+}
+
+// A sortable integer YYYYMMDD (missing month/day count as 0) — newest = largest.
+export function releaseSortKey(track) {
+  const rd = track && track.album && track.album.release_date;
+  if (!rd) return 0;
+  const [y, m, d] = rd.split("-");
+  return (
+    (parseInt(y, 10) || 0) * 10000 +
+    (parseInt(m, 10) || 0) * 100 +
+    (parseInt(d, 10) || 0)
+  );
+}


### PR DESCRIPTION
## What & why

Show when each track was released, and let you sort/filter by it.

## Features
- New **Released** column showing the track's release **month + year** ("Mar 2021"), or just the year when that's all Spotify provides (uses `album.release_date` / `release_date_precision` — no extra API calls).
- **Sort by** selector: Key (default), BPM, **Newest**, **Oldest**.
- **Release-year range** filter (From / To), alongside the existing BPM range.

## Implementation
- `utils/release.js`: `formatReleaseDate`, `releaseYear`, and a sortable `releaseSortKey` (YYYYMMDD).
- `Row`: the Released cell (non-tablet, to keep the table readable).
- `Playlist`: `sortBy` drives the memoized sort; year range folds into the existing filter pipeline. Pagination + memoized sort keep it fast.

> ⚠️ **Stacked on #44** (folders) to avoid a changelog/version clash. Merge #44 first.

Version → **1.16.0**, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)