### PR TITLE
Search selected crates (v1.17.0)

### DIFF
--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.17.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "Select specific crates (checkbox on each) to scope the cross-search \u2014 the 'Search all crates' button becomes 'Search selected (N)' and only searches those. With none selected it still searches all (non-hidden) crates.",
+      },
+    ],
+  },
+  {
     version: "1.16.0",
     date: "06/09/26",
     changes: [

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -17,6 +17,7 @@ import {
   CardContent,
   Typography,
   Box,
+  Checkbox,
   Chip,
   Collapse,
   FormControl,
@@ -237,6 +238,18 @@ let PLLibrary = (props) => {
   const [loadingId, setLoadingId] = React.useState(null);
   const [loadingAll, setLoadingAll] = React.useState(false);
   const [allProgress, setAllProgress] = React.useState({ done: 0, total: 0 });
+  // Crates selected (by id) to scope "Search all crates" to a subset.
+  const [selected, setSelected] = React.useState(() => new Set());
+
+  const toggleSelect = (id) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+  const clearSelection = () => setSelected(new Set());
   const [showPlaylist, setShowPlaylist] = React.useState(false);
   const [currPlaylist, setCurrPlaylist] = React.useState(null);
   const [playlistKeys, setPlaylistKeys] = React.useState(null);
@@ -536,10 +549,12 @@ let PLLibrary = (props) => {
   };
 
   const handleSearchAllCrates = async () => {
-    // Hidden crates are abstracted away — they don't feed the cross-search.
-    const playlists = (props.pllibrary || []).filter(
-      (pl) => !(crateMeta[pl.id] && crateMeta[pl.id].hidden)
-    );
+    // If crates are selected, search just those; otherwise all non-hidden crates
+    // (hidden crates are abstracted away and never feed the cross-search).
+    const playlists = (props.pllibrary || []).filter((pl) => {
+      if (selected.size > 0) return selected.has(pl.id);
+      return !(crateMeta[pl.id] && crateMeta[pl.id].hidden);
+    });
     if (playlists.length === 0) return;
 
     setAllProgress({ done: 0, total: playlists.length });
@@ -695,6 +710,14 @@ let PLLibrary = (props) => {
         </Box>
 
         <Box style={{ display: "flex", alignItems: "center", flexShrink: 0 }}>
+          <Checkbox
+            size="small"
+            checked={selected.has(playlist.id)}
+            onClick={(e) => e.stopPropagation()}
+            onChange={() => toggleSelect(playlist.id)}
+            title="Select for cross-search"
+            style={{ padding: 4 }}
+          />
           <IconButton
             size="small"
             onClick={(e) => openTagEdit(e, playlist)}
@@ -870,8 +893,21 @@ let PLLibrary = (props) => {
               flexShrink: 0,
             }}
           >
-            {isMobile ? "All crates" : "Search all crates"}
+            {selected.size > 0
+              ? `Search selected (${selected.size})`
+              : isMobile
+              ? "All crates"
+              : "Search all crates"}
           </Button>
+          {selected.size > 0 && (
+            <Button
+              size="small"
+              onClick={clearSelection}
+              style={{ color: "#fff", whiteSpace: "nowrap", flexShrink: 0 }}
+            >
+              Clear
+            </Button>
+          )}
         </Toolbar>
       </AppBar>
 

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -669,22 +669,24 @@ let PLLibrary = (props) => {
       }}
     >
       <CardContent className={classes.cardContent}>
-        <Checkbox
-          checked={selected.has(playlist.id)}
-          onClick={(e) => {
-            e.stopPropagation();
-            toggleSelect(playlist.id);
-          }}
-          title="Select for cross-search"
-          style={{ padding: 4, marginRight: 4, alignSelf: "center" }}
-        />
-        <Avatar
-          variant="square"
-          src={playlist.images[0] ? playlist.images[0].url : undefined}
-          className={classes.albumArt}
-        >
-          <MusicNote />
-        </Avatar>
+        <div style={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Checkbox
+            checked={selected.has(playlist.id)}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleSelect(playlist.id);
+            }}
+            title="Select for cross-search"
+            style={{ padding: 4 }}
+          />
+          <Avatar
+            variant="square"
+            src={playlist.images[0] ? playlist.images[0].url : undefined}
+            className={classes.albumArt}
+          >
+            <MusicNote />
+          </Avatar>
+        </div>
 
         <Box className={classes.playlistInfo}>
           <Box className={classes.playlistHeader}>

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -669,6 +669,15 @@ let PLLibrary = (props) => {
       }}
     >
       <CardContent className={classes.cardContent}>
+        <Checkbox
+          checked={selected.has(playlist.id)}
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleSelect(playlist.id);
+          }}
+          title="Select for cross-search"
+          style={{ padding: 4, marginRight: 4, alignSelf: "center" }}
+        />
         <Avatar
           variant="square"
           src={playlist.images[0] ? playlist.images[0].url : undefined}
@@ -710,14 +719,6 @@ let PLLibrary = (props) => {
         </Box>
 
         <Box style={{ display: "flex", alignItems: "center", flexShrink: 0 }}>
-          <Checkbox
-            size="small"
-            checked={selected.has(playlist.id)}
-            onClick={(e) => e.stopPropagation()}
-            onChange={() => toggleSelect(playlist.id)}
-            title="Select for cross-search"
-            style={{ padding: 4 }}
-          />
           <IconButton
             size="small"
             onClick={(e) => openTagEdit(e, playlist)}


### PR DESCRIPTION
## What & why

Batch item #4. Scope the cross-search to a chosen subset of crates instead of always searching everything.

## How it works
- A **checkbox** on each crate card selects it.
- With crates selected, the cross-search button becomes **"Search selected (N)"** and only loads/searches those crates; a **Clear** control resets the selection.
- With nothing selected, it still **"Search all crates"** (all non-hidden), as before.
- Selection is keyed by crate id, so it persists across pages and the flat/folder views.

Version → **1.17.0**, build passes.

## Next
Batch #5 — **Liked Songs as a crate** — then end-of-roadmap items + the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)