### PR TITLE
Liked Songs as a virtual crate (v1.18.0)

### DIFF
--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.18.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "Your Spotify Liked Songs now appear as a crate at the top of the library \u2014 open it to analyze keys/BPM, filter, sort, and add tracks to a set just like any playlist.",
+      },
+    ],
+  },
+  {
     version: "1.17.0",
     date: "06/09/26",
     changes: [

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -45,6 +45,7 @@ import {
   ExpandLess,
   Edit,
   Delete,
+  Favorite,
 } from "@material-ui/icons";
 
 import Spotify from "spotify-web-api-js";
@@ -596,6 +597,40 @@ let PLLibrary = (props) => {
     }
   };
 
+  // Open the user's Spotify Liked Songs as a virtual crate.
+  const handleOpenLikedSongs = async () => {
+    setLoadingPlaylist(true);
+    setLoadingId("__liked__");
+    try {
+      let items = [];
+      let offset = 0;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const res = await spotifyWebApi.getMySavedTracks({
+          limit: 50,
+          offset,
+        });
+        items = items.concat(res.items || []);
+        if (!res.next) break;
+        offset += 50;
+      }
+      const tracks = items.filter((it) => it.track && it.track.id);
+      const features = await fetchFeatures(tracks.map((t) => t.track.id));
+
+      setPlaylistName(`Liked Songs · ${tracks.length} tracks`);
+      setPlaylistId("__liked__");
+      setPlaylistOwnerId(null); // hides owner-only Recommendations
+      setCurrPlaylist(tracks);
+      setPlaylistKeys(features.filter(Boolean));
+      setShowPlaylist(true);
+    } catch (error) {
+      console.error("Failed to load liked songs", error);
+    } finally {
+      setLoadingPlaylist(false);
+      setLoadingId(null);
+    }
+  };
+
   // --- Folders ---
   const [folders, setFolders] = React.useState([]);
   const [folderView, setFolderView] = React.useState(false);
@@ -941,6 +976,54 @@ let PLLibrary = (props) => {
           Loading all crates… {allProgress.done}/{allProgress.total}
         </Typography>
       </Dialog>
+
+      {/* Liked Songs as a virtual crate */}
+      <Box sx={{ padding: isMobile ? 1 : 2 }} style={{ paddingBottom: 0 }}>
+        <Card
+          className={classes.playlistCard}
+          onClick={handleOpenLikedSongs}
+          style={{ borderLeft: "4px solid #1ED760" }}
+        >
+          <CardContent className={classes.cardContent}>
+            <Avatar
+              variant="square"
+              className={classes.albumArt}
+              style={{ background: "linear-gradient(135deg,#450af5,#c4efd9)" }}
+            >
+              <Favorite style={{ color: "#fff" }} />
+            </Avatar>
+            <Box className={classes.playlistInfo}>
+              <Box className={classes.playlistHeader}>
+                <Typography className={classes.playlistTitle}>
+                  Liked Songs
+                </Typography>
+              </Box>
+              <Typography className={classes.playlistDescription}>
+                Your Spotify Liked Songs
+              </Typography>
+            </Box>
+            {loadingId === "__liked__" ? (
+              <CircularProgress
+                classes={{ colorPrimary: classes.colorPrimary }}
+                size={24}
+                className={classes.openButton}
+              />
+            ) : (
+              !isMobile && (
+                <IconButton
+                  className={classes.openButton}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleOpenLikedSongs();
+                  }}
+                >
+                  <MenuOpen />
+                </IconButton>
+              )
+            )}
+          </CardContent>
+        </Card>
+      </Box>
 
       <Box
         sx={{ padding: isMobile ? 1 : 2 }}


### PR DESCRIPTION
## What & why

Last item of the crate batch. Surface your Spotify **Liked Songs** as a crate so you can analyze and mix them like any playlist.

## How it works
- A **"Liked Songs"** card is pinned at the top of the library (heart icon, gradient cover).
- Opening it loads your saved tracks (`getMySavedTracks`, paginated) + audio features and shows them in the normal **Playlist** view — so the whole toolkit applies: keys/BPM, the Camelot/piano key filter, BPM + release-year filters, sort (incl. newest/oldest), harmonic anchor, pagination, and **+ add to set**.
- No owner, so the owner-only Recommendations panel is hidden.

## Notes
- Uses the existing `user-library-read` scope (already requested at login).
- Big liked libraries take a moment to load (shows the crate loader); the memoized sort + pagination keep the view fast.
- Version → **1.18.0**, build passes.

## Roadmap
Crate-management batch complete. Remaining: playlist DNA · energy/vibe · recs upgrade · sortable columns → then the UI/mobile redesign pass and the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)