### PR TITLE
Crate DNA: key + BPM distribution (v1.20.0)

### DIFF
--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.20.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "Crate DNA: a 'Show Crate DNA' panel in each playlist with the key distribution (Camelot bars), a BPM histogram, and a summary (track count, BPM range, dominant key, major/minor split) \u2014 a quick read on a crate's character.",
+      },
+    ],
+  },
+  {
     version: "1.19.0",
     date: "06/09/26",
     changes: [

--- a/client/src/components/PLLibrary/CrateDNA.jsx
+++ b/client/src/components/PLLibrary/CrateDNA.jsx
@@ -1,0 +1,175 @@
+import React from "react";
+import { Box, Typography, Chip } from "@material-ui/core";
+
+import KeyMap from "../../utils/KeyMap";
+import { camelotColor } from "../../utils/harmonic";
+
+// A quick visual "DNA" of a crate: key distribution (Camelot bars) and a BPM
+// histogram, plus a one-line summary. Computed over the whole crate's tracks.
+const CrateDNA = ({ items, getKey }) => {
+  const data = React.useMemo(() => {
+    const keyCounts = {};
+    const bpms = [];
+    let major = 0;
+    let minor = 0;
+    (items || []).forEach((item) => {
+      const k = item && item.track && getKey(item.track.id);
+      if (!k) return;
+      const code = KeyMap[k.key].camelot[k.mode];
+      keyCounts[code] = (keyCounts[code] || 0) + 1;
+      bpms.push(Math.round(k.bpm));
+      if (k.mode === 1) major += 1;
+      else minor += 1;
+    });
+    return { keyCounts, bpms, major, minor };
+  }, [items, getKey]);
+
+  const total = data.major + data.minor;
+  if (total === 0) {
+    return (
+      <Typography variant="body2" color="textSecondary" style={{ padding: 8 }}>
+        No key/BPM data for this crate.
+      </Typography>
+    );
+  }
+
+  const keyEntries = Object.entries(data.keyCounts).sort((a, b) => {
+    const na = parseInt(a[0], 10);
+    const nb = parseInt(b[0], 10);
+    if (na !== nb) return na - nb;
+    return a[0].slice(-1).localeCompare(b[0].slice(-1));
+  });
+  const maxKeyCount = Math.max(...keyEntries.map((e) => e[1]));
+  const dominant = keyEntries.reduce(
+    (m, e) => (e[1] > m[1] ? e : m),
+    keyEntries[0]
+  );
+
+  const bpmMin = Math.min(...data.bpms);
+  const bpmMax = Math.max(...data.bpms);
+  const bins = {};
+  data.bpms.forEach((b) => {
+    const k = Math.floor(b / 10) * 10;
+    bins[k] = (bins[k] || 0) + 1;
+  });
+  const binEntries = Object.entries(bins)
+    .map(([k, v]) => [parseInt(k, 10), v])
+    .sort((a, b) => a[0] - b[0]);
+  const maxBin = Math.max(...binEntries.map((e) => e[1]));
+
+  return (
+    <Box style={{ padding: "8px 4px" }}>
+      <Box style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 12 }}>
+        <Chip size="small" label={`${total} tracks`} />
+        <Chip size="small" label={`${bpmMin}–${bpmMax} BPM`} />
+        <Chip
+          size="small"
+          label={`Dominant ${dominant[0]}`}
+          style={{
+            backgroundColor: camelotColor(dominant[0]).bg,
+            color: camelotColor(dominant[0]).text,
+          }}
+        />
+        <Chip
+          size="small"
+          label={`${Math.round((data.major / total) * 100)}% maj · ${Math.round(
+            (data.minor / total) * 100
+          )}% min`}
+        />
+      </Box>
+
+      <Typography variant="overline" color="textSecondary">
+        Key distribution
+      </Typography>
+      <Box style={{ marginBottom: 14 }}>
+        {keyEntries.map(([code, count]) => {
+          const c = camelotColor(code);
+          return (
+            <Box
+              key={code}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                marginBottom: 2,
+              }}
+            >
+              <span style={{ width: 36, fontSize: 11, fontWeight: 600 }}>
+                {code}
+              </span>
+              <Box
+                style={{
+                  flex: 1,
+                  background: "rgba(128,128,128,0.12)",
+                  borderRadius: 3,
+                }}
+              >
+                <Box
+                  style={{
+                    width: `${(count / maxKeyCount) * 100}%`,
+                    background: c.bg,
+                    height: 14,
+                    borderRadius: 3,
+                    minWidth: 2,
+                  }}
+                />
+              </Box>
+              <span
+                style={{
+                  width: 24,
+                  fontSize: 11,
+                  textAlign: "right",
+                  color: "#888",
+                }}
+              >
+                {count}
+              </span>
+            </Box>
+          );
+        })}
+      </Box>
+
+      <Typography variant="overline" color="textSecondary">
+        BPM distribution
+      </Typography>
+      <Box
+        style={{
+          display: "flex",
+          alignItems: "flex-end",
+          gap: 3,
+          height: 80,
+          marginTop: 4,
+        }}
+      >
+        {binEntries.map(([bin, count]) => (
+          <Box
+            key={bin}
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "flex-end",
+            }}
+            title={`${bin}-${bin + 9} BPM: ${count}`}
+          >
+            <Box
+              style={{
+                width: "100%",
+                background: "#1ED760",
+                height: `${(count / maxBin) * 100}%`,
+                minHeight: 2,
+                borderRadius: "3px 3px 0 0",
+              }}
+            />
+            <span style={{ fontSize: 9, color: "#888", marginTop: 2 }}>
+              {bin}
+            </span>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default CrateDNA;

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -30,7 +30,7 @@ import {
 } from "@material-ui/core";
 
 import { useTheme } from "@material-ui/core/styles";
-import { ArrowUpward, Close, Search, Delete, DonutLarge, FilterList, ExpandMore, ExpandLess, QueueMusic } from "@material-ui/icons";
+import { ArrowUpward, Close, Search, Delete, DonutLarge, FilterList, ExpandMore, ExpandLess, QueueMusic, Equalizer } from "@material-ui/icons";
 import Spotify from "spotify-web-api-js";
 
 import { initializeApp } from "firebase/app";
@@ -43,6 +43,7 @@ import { useEffect } from "react";
 import Row from "./Row";
 import Recommendations from "./Recommendations";
 import KeyFilterPicker from "./KeyFilterPicker";
+import CrateDNA from "./CrateDNA";
 
 initializeApp(firebaseConfig);
 
@@ -264,6 +265,7 @@ let Playlist = (props) => {
   const [minYear, setMinYear] = React.useState("");
   const [maxYear, setMaxYear] = React.useState("");
   const [sortBy, setSortBy] = React.useState("key");
+  const [showDNA, setShowDNA] = React.useState(false);
   const [showFilters, setShowFilters] = React.useState(!isMobile); // Collapsed on mobile by default
   let [searchItems, setSearchItems] = React.useState(allItems);
   // Track whose key is "anchored" for harmonic-mixing highlighting (or null).
@@ -757,6 +759,19 @@ let Playlist = (props) => {
           overflowX: isMobile ? "auto" : "visible",
           overflowY: "visible"
         }}>
+          <Box style={{ padding: "8px 16px" }}>
+            <Button
+              size="small"
+              startIcon={<Equalizer />}
+              onClick={() => setShowDNA((v) => !v)}
+              style={{ textTransform: "none" }}
+            >
+              {showDNA ? "Hide" : "Show"} Crate DNA
+            </Button>
+            <Collapse in={showDNA} timeout="auto" unmountOnExit>
+              <CrateDNA items={allItems} getKey={getKey} />
+            </Collapse>
+          </Box>
           {harmonicAnchorCamelot && (
             <Box
               style={{


### PR DESCRIPTION
## What & why

A quick visual read on a crate's musical character.

## Features
A **"Show Crate DNA"** toggle above the playlist table reveals:
- A **summary** line — track count, BPM range, **dominant key**, and major/minor split.
- **Key distribution** — a colored Camelot bar per key (how many tracks in each).
- **BPM distribution** — a histogram (10-BPM bins).

Computed over the whole crate; built with plain CSS bars (no charting dependency) and the existing Camelot colors. Collapsed by default.

Version → **1.20.0**, build passes.

## Next
End-of-roadmap continues: energy/vibe sort/filter · recs upgrade · sortable columns → then UI/mobile redesign → README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)