### PR TITLE
Energy & vibe: column, sort & filter (v1.21.0)

### DIFF
--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.21.0",
+    date: "06/09/26",
+    changes: [
+      {
+        type: "feature",
+        desc: "Energy & vibe: a new Energy column (colored meter per track), sort by Energy / Danceability / Valence, an Energy filter (Chill / Medium / Hype), and average energy/dance/valence in the Crate DNA summary.",
+      },
+    ],
+  },
+  {
     version: "1.20.0",
     date: "06/09/26",
     changes: [

--- a/client/src/components/PLLibrary/CrateDNA.jsx
+++ b/client/src/components/PLLibrary/CrateDNA.jsx
@@ -12,6 +12,10 @@ const CrateDNA = ({ items, getKey }) => {
     const bpms = [];
     let major = 0;
     let minor = 0;
+    let energy = 0;
+    let dance = 0;
+    let valence = 0;
+    let vibeN = 0;
     (items || []).forEach((item) => {
       const k = item && item.track && getKey(item.track.id);
       if (!k) return;
@@ -20,8 +24,22 @@ const CrateDNA = ({ items, getKey }) => {
       bpms.push(Math.round(k.bpm));
       if (k.mode === 1) major += 1;
       else minor += 1;
+      if (k.energy != null) {
+        energy += k.energy;
+        dance += k.danceability || 0;
+        valence += k.valence || 0;
+        vibeN += 1;
+      }
     });
-    return { keyCounts, bpms, major, minor };
+    return {
+      keyCounts,
+      bpms,
+      major,
+      minor,
+      energy: vibeN ? energy / vibeN : null,
+      dance: vibeN ? dance / vibeN : null,
+      valence: vibeN ? valence / vibeN : null,
+    };
   }, [items, getKey]);
 
   const total = data.major + data.minor;
@@ -76,6 +94,14 @@ const CrateDNA = ({ items, getKey }) => {
             (data.minor / total) * 100
           )}% min`}
         />
+        {data.energy != null && (
+          <Chip
+            size="small"
+            label={`Energy ${Math.round(data.energy * 100)}% · Dance ${Math.round(
+              data.dance * 100
+            )}% · Valence ${Math.round(data.valence * 100)}%`}
+          />
+        )}
       </Box>
 
       <Typography variant="overline" color="textSecondary">

--- a/client/src/components/PLLibrary/CrateDNA.jsx
+++ b/client/src/components/PLLibrary/CrateDNA.jsx
@@ -183,8 +183,7 @@ const CrateDNA = ({ items, getKey }) => {
               style={{
                 width: "100%",
                 background: "#1ED760",
-                height: `${(count / maxBin) * 100}%`,
-                minHeight: 2,
+                height: Math.max(2, Math.round((count / maxBin) * 64)),
                 borderRadius: "3px 3px 0 0",
               }}
             />

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -265,6 +265,7 @@ let Playlist = (props) => {
   const [minYear, setMinYear] = React.useState("");
   const [maxYear, setMaxYear] = React.useState("");
   const [sortBy, setSortBy] = React.useState("key");
+  const [energyFilter, setEnergyFilter] = React.useState("any");
   const [showDNA, setShowDNA] = React.useState(false);
   const [showFilters, setShowFilters] = React.useState(!isMobile); // Collapsed on mobile by default
   let [searchItems, setSearchItems] = React.useState(allItems);
@@ -330,7 +331,14 @@ let Playlist = (props) => {
       if (!id) return undefined;
       const result = keysById.get(id);
       return result
-        ? { key: result.key, mode: result.mode, bpm: result.tempo }
+        ? {
+            key: result.key,
+            mode: result.mode,
+            bpm: result.tempo,
+            energy: result.energy,
+            danceability: result.danceability,
+            valence: result.valence,
+          }
         : null;
     },
     [keysById]
@@ -377,6 +385,12 @@ let Playlist = (props) => {
       if (!aKey) return -1;
       if (!bKey) return 1;
       if (sortBy === "bpm") return aKey.bpm - bKey.bpm;
+      // Energy / danceability / valence: highest first.
+      if (sortBy === "energy") return (bKey.energy || 0) - (aKey.energy || 0);
+      if (sortBy === "danceability")
+        return (bKey.danceability || 0) - (aKey.danceability || 0);
+      if (sortBy === "valence")
+        return (bKey.valence || 0) - (aKey.valence || 0);
       // Default: Camelot key, then BPM.
       const aCamelot = KeyMap[aKey.key].camelot[aKey.mode];
       const bCamelot = KeyMap[bKey.key].camelot[bKey.mode];
@@ -405,7 +419,8 @@ let Playlist = (props) => {
       minBpm === "" &&
       maxBpm === "" &&
       minYear === "" &&
-      maxYear === ""
+      maxYear === "" &&
+      energyFilter === "any"
     ) {
       _.debounce(setSearchItems(allItems), 500);
     } else {
@@ -469,12 +484,22 @@ let Playlist = (props) => {
               return ry !== null && ry <= y;
             });
           }
+          if (energyFilter !== "any") {
+            filteredItems = filteredItems.filter((item) => {
+              const tk = getKey(item.track.id);
+              const e = tk ? tk.energy : null;
+              if (e == null) return false;
+              if (energyFilter === "low") return e < 0.4;
+              if (energyFilter === "med") return e >= 0.4 && e <= 0.7;
+              return e > 0.7;
+            });
+          }
           return filteredItems;
         }, 500)
       );
     }
     // `wheel` only changes the displayed notation, not which tracks match.
-  }, [search, keyFilter, minBpm, maxBpm, minYear, maxYear]);
+  }, [search, keyFilter, minBpm, maxBpm, minYear, maxYear, energyFilter]);
 
   const handleFilterChange = (event, type) => {
     const {
@@ -500,6 +525,7 @@ let Playlist = (props) => {
     setMaxBpm("");
     setMinYear("");
     setMaxYear("");
+    setEnergyFilter("any");
     ["minBpm", "maxBpm", "minYear", "maxYear"].forEach((id) => {
       const el = document.getElementById(id);
       if (el) el.value = "";
@@ -736,6 +762,26 @@ let Playlist = (props) => {
                   <MenuItem value="bpm">BPM</MenuItem>
                   <MenuItem value="released-desc">Newest</MenuItem>
                   <MenuItem value="released-asc">Oldest</MenuItem>
+                  <MenuItem value="energy">Energy</MenuItem>
+                  <MenuItem value="danceability">Danceability</MenuItem>
+                  <MenuItem value="valence">Valence (happy)</MenuItem>
+                </Select>
+              </FormControl>
+              <FormControl className={classes.filter}>
+                <InputLabel id="demo-simple-select-label">Energy</InputLabel>
+                <Select
+                  value={energyFilter}
+                  label="Energy"
+                  onChange={(e) => setEnergyFilter(e.target.value)}
+                  inputProps={{
+                    classes: { icon: classes.icon, root: classes.root },
+                  }}
+                  input={<Input />}
+                >
+                  <MenuItem value="any">Any energy</MenuItem>
+                  <MenuItem value="low">Chill</MenuItem>
+                  <MenuItem value="med">Medium</MenuItem>
+                  <MenuItem value="high">Hype</MenuItem>
                 </Select>
               </FormControl>
 
@@ -822,6 +868,7 @@ let Playlist = (props) => {
                 {!isMobile && <StyledTableCell>Quality</StyledTableCell>}
                 <StyledTableCell>BPM</StyledTableCell>
                 {!isTablet && <StyledTableCell>Released</StyledTableCell>}
+                {!isTablet && <StyledTableCell>Energy</StyledTableCell>}
               </TableRow>
             </TableHead>
             <TableBody>

--- a/client/src/components/PLLibrary/Row.jsx
+++ b/client/src/components/PLLibrary/Row.jsx
@@ -156,6 +156,32 @@ let Row = (props) => {
           {formatReleaseDate(item.track)}
         </TableCell>
       )}
+      {!props.isTablet && (
+        <TableCell>
+          {trackKey && trackKey.energy != null ? (
+            <div
+              title={`Energy ${Math.round(trackKey.energy * 100)}%`}
+              style={{
+                width: 46,
+                height: 6,
+                background: "rgba(128,128,128,0.2)",
+                borderRadius: 3,
+              }}
+            >
+              <div
+                style={{
+                  width: `${Math.round(trackKey.energy * 100)}%`,
+                  height: 6,
+                  borderRadius: 3,
+                  background: `hsl(${(1 - trackKey.energy) * 200}, 75%, 48%)`,
+                }}
+              />
+            </div>
+          ) : (
+            "—"
+          )}
+        </TableCell>
+      )}
     </TableRow>
   );
 };


### PR DESCRIPTION
## What & why

Spotify's audio features (which we already fetch for key/BPM) also include **energy**, **danceability**, and **valence**. This surfaces them.

## Features
- **Energy column** — a small colored meter per track (cool = chill, warm = hype), desktop/non-tablet.
- **Sort** by **Energy**, **Danceability**, or **Valence (happy)** — highest first.
- **Energy filter** — Chill (<0.4) / Medium / Hype (>0.7).
- **Crate DNA** summary now shows **average** energy / danceability / valence.

## Implementation
- `getKey` returns `energy`/`danceability`/`valence` (already present in the fetched features — no new API calls).
- Sort + filter fold into the existing memoized pipeline (stays fast with pagination).
- Depends on Audio Features access (which this app has).

Version → **1.21.0**, build passes.

## Next
**Recs upgrade** (rank by harmonic + BPM compatibility) → **sortable columns** → UI/mobile redesign → README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)