### PR TITLE
Widen crate library to full width with a 2-up grid (v1.24.0)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -604,7 +604,15 @@ class App extends React.Component {
           </Toolbar>
         </AppBar>
 
-        <Container style={{ paddingTop: 24, paddingBottom: 130 }}>
+        <Container
+          maxWidth={false}
+          style={{
+            paddingTop: 24,
+            paddingBottom: 130,
+            maxWidth: 1400,
+            margin: "0 auto",
+          }}
+        >
           <Grid container spacing={2} justify="center">
             {this.renderTile(
               <LibraryMusic style={tileIcon} />,

--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.24.0",
+    date: "06/10/26",
+    changes: [
+      {
+        type: "improvement",
+        desc: "Library layout refresh: the crate library now uses the full page width and lays crates out in a responsive two-per-row grid on desktop instead of one sparse full-width row each, and the 'Sort crates by' / tag-genre filter controls were restyled as clean outlined dropdowns.",
+      },
+    ],
+  },
+  {
     version: "1.23.0",
     date: "06/10/26",
     changes: [

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -15,6 +15,7 @@ import {
   makeStyles,
   Card,
   CardContent,
+  Grid,
   Typography,
   Box,
   Checkbox,
@@ -698,6 +699,8 @@ let PLLibrary = (props) => {
       className={classes.playlistCard}
       onClick={() => handlePlaylistOpen(playlist)}
       style={{
+        height: "100%",
+        marginBottom: 0,
         borderLeft: metaFor(playlist.id).favorite
           ? "4px solid #1ED760"
           : "4px solid transparent",
@@ -813,6 +816,18 @@ let PLLibrary = (props) => {
     </Card>
   );
 
+  // Lay crates out in a responsive grid so wide screens show two cards per
+  // row instead of one sparse full-width row with lots of empty space.
+  const renderCrateGrid = (crates) => (
+    <Grid container spacing={2}>
+      {crates.map((p) => (
+        <Grid item xs={12} md={6} key={p.id}>
+          {renderCrateCard(p)}
+        </Grid>
+      ))}
+    </Grid>
+  );
+
   const renderFolderGroup = (key, name, crates, folder) => (
     <Box key={key} style={{ marginBottom: 8 }}>
       <Box
@@ -870,7 +885,7 @@ let PLLibrary = (props) => {
               No crates
             </Typography>
           ) : (
-            crates.map(renderCrateCard)
+            renderCrateGrid(crates)
           )}
         </Box>
       </Collapse>
@@ -1036,7 +1051,7 @@ let PLLibrary = (props) => {
         }}
       >
         <Box style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-          <FormControl size="small" style={{ minWidth: 150 }}>
+          <FormControl variant="outlined" size="small" style={{ minWidth: 160 }}>
             <InputLabel>Sort crates by</InputLabel>
             <Select
               value={crateSort}
@@ -1049,7 +1064,7 @@ let PLLibrary = (props) => {
             </Select>
           </FormControl>
           {allTagsGenres.length > 0 && (
-            <FormControl size="small" style={{ minWidth: 170 }}>
+            <FormControl variant="outlined" size="small" style={{ minWidth: 180 }}>
               <InputLabel>Filter by tag/genre</InputLabel>
               <Select
                 multiple
@@ -1134,7 +1149,7 @@ let PLLibrary = (props) => {
         </Box>
       ) : (
         <Box sx={{ padding: isMobile ? 1 : 2 }}>
-          {pagedCrates.map(renderCrateCard)}
+          {renderCrateGrid(pagedCrates)}
         </Box>
       )}
 


### PR DESCRIPTION
## What

First pass of the deferred UI polish. Targets the two desktop-layout complaints: the library felt **narrow** and each crate row was **sparse** with lots of empty horizontal space.

## Changes

- **Full-width library** — the logged-in dashboard `<Container>` no longer caps at MUI's default `lg`; it now spans the page (capped at 1400px for very wide monitors).
- **Responsive crate grid** — crates lay out **two cards per row on desktop**, one on mobile, instead of a single sparse full-width row each. Applies to both the flat list and folder groups; cards are equal-height within a row.
- **Restyled controls** — the "Sort crates by" and tag/genre filter dropdowns are now clean **outlined** selects.

## Notes

- Mobile **card-per-track** layout for the track table (the other deferred item) is coming as a **separate follow-up PR** to keep this one reviewable.
- Changelog + version bump to **1.24.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)