### PR TITLE
Trim duplicate Set Builder + theme toggle from the top bar (v1.26.0)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -625,7 +625,6 @@ class App extends React.Component {
   // left sidebar that navigates between Library, Key Calculator, Sets,
   // Favorites and Hidden crates. Account/Current Song still live in the drawer.
   renderHome(version) {
-    const isDark = this.state.themeMode === 'dark';
     const userInitial = this.state.user_name
       ? this.state.user_name.charAt(0).toUpperCase()
       : '?';
@@ -744,28 +743,11 @@ class App extends React.Component {
               <CurrentSong token={this.state.access_token} compact />
             </Hidden>
             <IconButton
-              color="inherit"
-              onClick={this.openSet}
-              title="Set Builder"
-              aria-label="set builder"
-            >
-              <Badge badgeContent={this.state.set.length} color="primary">
-                <QueueMusic />
-              </Badge>
-            </IconButton>
-            <IconButton
-              color="inherit"
-              onClick={this.toggleTheme}
-              title="Toggle dark mode"
-              aria-label="toggle theme"
-            >
-              {isDark ? <Brightness7 /> : <Brightness4 />}
-            </IconButton>
-            <IconButton
               edge="end"
               onClick={() => this.setState({ drawerOpen: true })}
               title="Account"
               aria-label="account"
+              style={{ marginLeft: 8 }}
             >
               <Avatar
                 style={{

--- a/client/src/changelog.js
+++ b/client/src/changelog.js
@@ -1,5 +1,15 @@
 const changelog = [
   {
+    version: "1.26.0",
+    date: "06/10/26",
+    changes: [
+      {
+        type: "improvement",
+        desc: "Trimmed the top bar: removed the duplicate Set Builder and dark-mode buttons (Sets lives in the nav, dark mode in the account menu) so the slim Now Playing control sits cleanly at the right next to your avatar.",
+      },
+    ],
+  },
+  {
     version: "1.25.0",
     date: "06/10/26",
     changes: [


### PR DESCRIPTION
The top bar had a Set Builder icon and a dark-mode toggle that are now duplicated elsewhere — **Sets** lives in the sidebar/nav and **dark mode** in the account drawer. Removed both so the bar is just **logo · Now Playing · avatar**, with the slim Now Playing control sitting cleanly at the right.

Changelog + version bump to **1.26.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)