### PR TITLE
SoundCloud crate tiles + track table — tickets #3b & #3c

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -57,6 +57,7 @@ import FadeIn from 'react-fade-in';
 
 import changelog from './changelog.js';
 import CurrentSong from './components/CurrentSong/CurrentSong';
+import SoundCloudLibrary from './components/SoundCloud/SoundCloudLibrary';
 import PLLibrary from './components/PLLibrary/PLLibrary';
 import SetBuilder from './components/PLLibrary/SetBuilder';
 import KeyCalculator from './utils/KeyCalculator';
@@ -149,6 +150,9 @@ class App extends React.Component {
       showHiddenCrates: false,
       // Library view filter driven by the "Favorites" sidebar item.
       favoritesOnly: false,
+      // When true, the main content shows the SoundCloud source (separate
+      // from the Spotify library).
+      showSoundcloud: false,
       // App-level set so it spans playlists. Entries are { item, key }.
       set: [],
       setOpen: false,
@@ -185,6 +189,7 @@ class App extends React.Component {
     this.connectSoundcloud = this.connectSoundcloud.bind(this);
     this.disconnectSoundcloud = this.disconnectSoundcloud.bind(this);
     this.refreshSoundcloudToken = this.refreshSoundcloudToken.bind(this);
+    this.openSoundcloud = this.openSoundcloud.bind(this);
     this.getUserPlaylists = this.getUserPlaylists.bind(this);
     this.openKeyCalculator = this.openKeyCalculator.bind(this);
     this.toggleTheme = this.toggleTheme.bind(this);
@@ -399,7 +404,11 @@ class App extends React.Component {
     if (!this.state.pllibrary) {
       await this.getUserPlaylists();
     }
-    this.setState({ showHiddenCrates: true, favoritesOnly: false });
+    this.setState({
+      showHiddenCrates: true,
+      favoritesOnly: false,
+      showSoundcloud: false,
+    });
   }
 
   exitHidden() {
@@ -453,10 +462,22 @@ class App extends React.Component {
     }
   }
 
+  // Sidebar "SoundCloud": switch the main content to the SoundCloud source.
+  openSoundcloud() {
+    this.setState({
+      showSoundcloud: true,
+      showPlaylists: false,
+      showHiddenCrates: false,
+      favoritesOnly: false,
+      drawerOpen: false,
+      navDrawerOpen: false,
+    });
+  }
+
   // Sidebar "Library": always lands on the full crate list (loading on first
   // open). Unlike the old toggle tile, navigating here never closes the view.
   async openLibrary() {
-    this.setState({ drawerOpen: false });
+    this.setState({ drawerOpen: false, showSoundcloud: false });
     if (!this.state.pllibrary) {
       await this.getUserPlaylists();
     }
@@ -469,7 +490,7 @@ class App extends React.Component {
 
   // Sidebar "Favorites": the library scoped to favorited crates.
   async openFavorites() {
-    this.setState({ drawerOpen: false });
+    this.setState({ drawerOpen: false, showSoundcloud: false });
     if (!this.state.pllibrary) {
       await this.getUserPlaylists();
     }
@@ -739,6 +760,18 @@ class App extends React.Component {
         onClick: this.openHiddenCrates,
         active: this.state.showHiddenCrates,
       },
+      // Only surfaced once a SoundCloud account is connected.
+      ...(this.state.soundcloud.connected
+        ? [
+            {
+              key: 'soundcloud',
+              icon: <Cloud style={{ color: '#ff5500' }} />,
+              label: 'SoundCloud',
+              onClick: this.openSoundcloud,
+              active: this.state.showSoundcloud,
+            },
+          ]
+        : []),
     ];
 
     // Shared between the persistent desktop sidebar and the mobile nav drawer.
@@ -895,7 +928,15 @@ class App extends React.Component {
           </Drawer>
 
           <Box style={{ flex: 1, minWidth: 0 }}>
-            {this.state.showPlaylists ? (
+            {this.state.showSoundcloud ? (
+              <FadeIn transitionDuration={400}>
+                <SoundCloudLibrary
+                  token={this.state.soundcloud.access_token}
+                  backend={soundcloudBackend}
+                  onRefreshToken={this.refreshSoundcloudToken}
+                />
+              </FadeIn>
+            ) : this.state.showPlaylists ? (
               <FadeIn transitionDuration={400}>
                 <PLLibrary
                   token={this.state.access_token}

--- a/client/src/components/SoundCloud/SoundCloudLibrary.jsx
+++ b/client/src/components/SoundCloud/SoundCloudLibrary.jsx
@@ -1,16 +1,31 @@
 import React from "react";
 import axios from "axios";
 import {
+  Avatar,
   Box,
   Card,
   CardContent,
   Chip,
   CircularProgress,
   Grid,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
   Typography,
   makeStyles,
+  withStyles,
 } from "@material-ui/core";
-import { Cloud, MusicNote, Favorite, Repeat } from "@material-ui/icons";
+import {
+  Cloud,
+  MusicNote,
+  Favorite,
+  Repeat,
+  ArrowBack,
+  OpenInNew,
+} from "@material-ui/icons";
 
 // SoundCloud's brand orange — used for the source badge so SoundCloud crates
 // are always visually distinct from Spotify's green (strict source separation).
@@ -71,10 +86,24 @@ const useStyles = makeStyles((theme) => ({
 const bigArtwork = (url) =>
   url ? url.replace("-large", "-t500x500") : null;
 
+const fmtDuration = (ms) => {
+  if (!ms) return "—";
+  const s = Math.round(ms / 1000);
+  return Math.floor(s / 60) + ":" + String(s % 60).padStart(2, "0");
+};
+
+// Orange table header to match the SoundCloud source color.
+const ScHeadCell = withStyles({
+  head: { backgroundColor: SC_ORANGE, color: "#fff", fontWeight: "bold" },
+})(TableCell);
+
 let SoundCloudLibrary = (props) => {
   const classes = useStyles();
   const [crates, setCrates] = React.useState(null);
   const [error, setError] = React.useState(null);
+  // Crate-detail view: the opened crate + its tracks (null while loading).
+  const [opened, setOpened] = React.useState(null);
+  const [tracks, setTracks] = React.useState(null);
 
   // Call the backend proxy with the SoundCloud token. On a 401 (expired access
   // token) refresh once and retry, mirroring the Spotify session handling.
@@ -100,6 +129,33 @@ let SoundCloudLibrary = (props) => {
     },
     [props]
   );
+
+  // Open a crate → fetch its tracks. Likes/reposts have their own endpoints;
+  // a playlist's tracks come from /playlists/:urn/tracks.
+  const openCrate = async (crate) => {
+    setOpened(crate);
+    setTracks(null);
+    const path =
+      crate.kind === "likes"
+        ? "/soundcloud/me/likes/tracks"
+        : crate.kind === "reposts"
+        ? "/soundcloud/me/reposts"
+        : "/soundcloud/playlists/" + encodeURIComponent(crate.id) + "/tracks";
+    try {
+      const data = await scFetch(path);
+      const list = data && data.collection ? data.collection : Array.isArray(data) ? data : [];
+      // Likes/reposts come back as { track: {...} } wrappers on some endpoints.
+      setTracks(list.map((t) => (t && t.track ? t.track : t)).filter(Boolean));
+    } catch (e) {
+      console.error("Failed to load SoundCloud crate", e);
+      setTracks([]);
+    }
+  };
+
+  const closeCrate = () => {
+    setOpened(null);
+    setTracks(null);
+  };
 
   React.useEffect(() => {
     let cancelled = false;
@@ -173,6 +229,96 @@ let SoundCloudLibrary = (props) => {
     return <MusicNote style={{ color: "#fff", fontSize: 40, opacity: 0.85 }} />;
   };
 
+  // Crate detail: the opened crate's track table.
+  if (opened) {
+    return (
+      <Box style={{ padding: 16 }}>
+        <Box
+          style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}
+        >
+          <IconButton size="small" onClick={closeCrate} title="Back to crates">
+            <ArrowBack />
+          </IconButton>
+          <Cloud style={{ color: SC_ORANGE }} />
+          <Typography variant="h6" style={{ fontWeight: 700 }} noWrap>
+            {opened.name}
+          </Typography>
+          <Typography variant="caption" color="textSecondary">
+            {opened.count} tracks
+          </Typography>
+        </Box>
+
+        {!tracks ? (
+          <Box style={{ padding: 48, textAlign: "center" }}>
+            <CircularProgress style={{ color: SC_ORANGE }} />
+          </Box>
+        ) : tracks.length === 0 ? (
+          <Typography color="textSecondary" style={{ padding: 16 }}>
+            No tracks in this crate.
+          </Typography>
+        ) : (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <ScHeadCell></ScHeadCell>
+                <ScHeadCell>Track</ScHeadCell>
+                <ScHeadCell>Artist</ScHeadCell>
+                <ScHeadCell>Key</ScHeadCell>
+                <ScHeadCell>BPM</ScHeadCell>
+                <ScHeadCell>Genre</ScHeadCell>
+                <ScHeadCell>Length</ScHeadCell>
+                <ScHeadCell></ScHeadCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {tracks.map((t) => (
+                <TableRow key={t.urn || t.id} hover>
+                  <TableCell style={{ width: 48 }}>
+                    <Avatar
+                      variant="rounded"
+                      src={t.artwork_url}
+                      style={{ width: 36, height: 36 }}
+                    >
+                      <MusicNote />
+                    </Avatar>
+                  </TableCell>
+                  <TableCell style={{ fontWeight: 600 }}>{t.title}</TableCell>
+                  <TableCell>{t.user && t.user.username}</TableCell>
+                  <TableCell>{t.key_signature || "—"}</TableCell>
+                  <TableCell>{t.bpm || "—"}</TableCell>
+                  <TableCell>{t.genre || "—"}</TableCell>
+                  <TableCell style={{ whiteSpace: "nowrap" }}>
+                    {fmtDuration(t.duration)}
+                  </TableCell>
+                  <TableCell>
+                    <IconButton
+                      size="small"
+                      href={t.permalink_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title="Open on SoundCloud"
+                    >
+                      <OpenInNew fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+
+        <Typography
+          variant="caption"
+          color="textSecondary"
+          style={{ display: "block", marginTop: 12 }}
+        >
+          Key &amp; BPM are artist-entered (usually blank) — KeyTrack analysis
+          comes next. Tracks link out to SoundCloud (source &amp; attribution).
+        </Typography>
+      </Box>
+    );
+  }
+
   if (error) {
     return (
       <Box style={{ padding: 32, textAlign: "center" }}>
@@ -207,10 +353,7 @@ let SoundCloudLibrary = (props) => {
       <Grid container spacing={2}>
         {crates.map((c) => (
           <Grid item xs={12} sm={6} md={4} lg={3} key={c.id}>
-            <Card
-              className={classes.tile}
-              onClick={() => props.onOpenCrate && props.onOpenCrate(c)}
-            >
+            <Card className={classes.tile} onClick={() => openCrate(c)}>
               <Box
                 className={classes.cover}
                 style={

--- a/client/src/components/SoundCloud/SoundCloudLibrary.jsx
+++ b/client/src/components/SoundCloud/SoundCloudLibrary.jsx
@@ -1,0 +1,249 @@
+import React from "react";
+import axios from "axios";
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Grid,
+  Typography,
+  makeStyles,
+} from "@material-ui/core";
+import { Cloud, MusicNote, Favorite, Repeat } from "@material-ui/icons";
+
+// SoundCloud's brand orange — used for the source badge so SoundCloud crates
+// are always visually distinct from Spotify's green (strict source separation).
+const SC_ORANGE = "#ff5500";
+
+const useStyles = makeStyles((theme) => ({
+  tile: {
+    cursor: "pointer",
+    borderRadius: 12,
+    overflow: "hidden",
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
+    border: "1px solid rgba(128,128,128,0.18)",
+    transition: "all 0.18s ease-in-out",
+    "&:hover": {
+      transform: "translateY(-3px)",
+      boxShadow: theme.shadows[6],
+    },
+  },
+  cover: {
+    position: "relative",
+    height: 130,
+    backgroundColor: "#191414",
+    backgroundSize: "cover",
+    backgroundPosition: "center",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  scBadge: {
+    position: "absolute",
+    top: 6,
+    left: 6,
+    display: "flex",
+    alignItems: "center",
+    gap: 4,
+    backgroundColor: SC_ORANGE,
+    color: "#fff",
+    fontSize: 11,
+    fontWeight: 700,
+    padding: "2px 8px",
+    borderRadius: 12,
+  },
+  body: { flex: 1, padding: theme.spacing(1.5) },
+  title: { fontWeight: 600, fontSize: "1.05rem" },
+  owner: { fontSize: "0.8rem", color: theme.palette.text.secondary },
+  trackChip: {
+    backgroundColor: SC_ORANGE,
+    color: "#fff",
+    fontWeight: 600,
+    height: 24,
+    marginTop: theme.spacing(1),
+  },
+}));
+
+// Swap SoundCloud's small "-large" artwork variant for a bigger one.
+const bigArtwork = (url) =>
+  url ? url.replace("-large", "-t500x500") : null;
+
+let SoundCloudLibrary = (props) => {
+  const classes = useStyles();
+  const [crates, setCrates] = React.useState(null);
+  const [error, setError] = React.useState(null);
+
+  // Call the backend proxy with the SoundCloud token. On a 401 (expired access
+  // token) refresh once and retry, mirroring the Spotify session handling.
+  const scFetch = React.useCallback(
+    async (path, retried = false) => {
+      try {
+        const res = await axios.get(props.backend + path, {
+          headers: { Authorization: "OAuth " + props.token },
+        });
+        return res.data;
+      } catch (e) {
+        if (e.response && e.response.status === 401 && !retried && props.onRefreshToken) {
+          const fresh = await props.onRefreshToken();
+          if (fresh) {
+            const res = await axios.get(props.backend + path, {
+              headers: { Authorization: "OAuth " + fresh },
+            });
+            return res.data;
+          }
+        }
+        throw e;
+      }
+    },
+    [props]
+  );
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const [playlists, likes, reposts] = await Promise.all([
+          scFetch("/soundcloud/me/playlists").catch(() => ({ collection: [] })),
+          scFetch("/soundcloud/me/likes/tracks").catch(() => ({ collection: [] })),
+          scFetch("/soundcloud/me/reposts").catch(() => ({ collection: [] })),
+        ]);
+        if (cancelled) return;
+
+        const list = (d) => (d && d.collection ? d.collection : Array.isArray(d) ? d : []);
+        const likeTracks = list(likes);
+        const repostTracks = list(reposts);
+
+        const result = [];
+        // Liked + reposted tracks as virtual crates (artwork from first track).
+        if (likeTracks.length) {
+          result.push({
+            id: "__sc_likes__",
+            kind: "likes",
+            name: "Liked Tracks",
+            owner: "Your likes",
+            count: likeTracks.length,
+            artwork: bigArtwork(likeTracks[0] && likeTracks[0].artwork_url),
+          });
+        }
+        if (repostTracks.length) {
+          result.push({
+            id: "__sc_reposts__",
+            kind: "reposts",
+            name: "Reposts",
+            owner: "Your reposts",
+            count: repostTracks.length,
+            artwork: bigArtwork(repostTracks[0] && repostTracks[0].artwork_url),
+          });
+        }
+        // The user's playlists / sets.
+        list(playlists).forEach((p) => {
+          result.push({
+            id: p.urn || p.id,
+            kind: "playlist",
+            name: p.title,
+            owner: p.user && p.user.username ? "by " + p.user.username : "",
+            count: p.track_count,
+            artwork:
+              bigArtwork(p.artwork_url) ||
+              bigArtwork(
+                p.tracks && p.tracks[0] && p.tracks[0].artwork_url
+              ),
+            permalink: p.permalink_url,
+          });
+        });
+
+        setCrates(result);
+      } catch (e) {
+        console.error("Failed to load SoundCloud library", e);
+        if (!cancelled) setError("Couldn't load your SoundCloud library.");
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [scFetch]);
+
+  const kindIcon = (kind) => {
+    if (kind === "likes") return <Favorite style={{ color: "#fff", fontSize: 40 }} />;
+    if (kind === "reposts") return <Repeat style={{ color: "#fff", fontSize: 40 }} />;
+    return <MusicNote style={{ color: "#fff", fontSize: 40, opacity: 0.85 }} />;
+  };
+
+  if (error) {
+    return (
+      <Box style={{ padding: 32, textAlign: "center" }}>
+        <Typography color="textSecondary">{error}</Typography>
+      </Box>
+    );
+  }
+
+  if (!crates) {
+    return (
+      <Box style={{ padding: 64, textAlign: "center" }}>
+        <CircularProgress style={{ color: SC_ORANGE }} />
+        <Typography color="textSecondary" style={{ marginTop: 12 }}>
+          Loading your SoundCloud library…
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box style={{ padding: 16 }}>
+      <Box style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+        <Cloud style={{ color: SC_ORANGE }} />
+        <Typography variant="h6" style={{ fontWeight: 700 }}>
+          SoundCloud
+        </Typography>
+        <Typography variant="caption" color="textSecondary">
+          {crates.length} crate{crates.length === 1 ? "" : "s"}
+        </Typography>
+      </Box>
+
+      <Grid container spacing={2}>
+        {crates.map((c) => (
+          <Grid item xs={12} sm={6} md={4} lg={3} key={c.id}>
+            <Card
+              className={classes.tile}
+              onClick={() => props.onOpenCrate && props.onOpenCrate(c)}
+            >
+              <Box
+                className={classes.cover}
+                style={
+                  c.artwork ? { backgroundImage: `url(${c.artwork})` } : {}
+                }
+              >
+                {!c.artwork && kindIcon(c.kind)}
+                <span className={classes.scBadge}>
+                  <Cloud style={{ fontSize: 13 }} /> SoundCloud
+                </span>
+              </Box>
+              <CardContent className={classes.body}>
+                <Typography className={classes.title} noWrap title={c.name}>
+                  {c.name}
+                </Typography>
+                {c.owner && (
+                  <Typography className={classes.owner} noWrap>
+                    {c.owner}
+                  </Typography>
+                )}
+                <Chip
+                  size="small"
+                  className={classes.trackChip}
+                  icon={<MusicNote style={{ color: "#fff" }} />}
+                  label={`${c.count} tracks`}
+                />
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export default SoundCloudLibrary;


### PR DESCRIPTION
**Heads up:** #62 was merged when its head was only ticket **#3a**, so ticket **#3b** (crate tiles) never reached master. This PR carries **both #3b and #3c**.

## #3b — crate tiles (was orphaned after #62 merged early)
Isolated `SoundCloudLibrary` component (kept separate from the Spotify-coupled `PLLibrary` for strict source separation) that fetches your playlists + likes + reposts via the proxy and renders them as cover-art tiles with an **orange "SoundCloud" badge**. Wired into the sidebar as a "SoundCloud" nav item (only shown once connected) that swaps cleanly with the Spotify library.

## #3c — crate → track table
Clicking a crate opens a detail view: fetches its tracks and renders **artwork, title, artist, artist-entered key/BPM** (mostly blank until analysis lands), **genre, length**, with a Back button and per-row **"open on SoundCloud"** links (source + attribution per ToS).

Both verified live. Next: ticket **#3d** (embedded Widget playback), then Phase 1 (the analysis engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)