### PR TITLE
Flag DJ sets (>6 min) + exclude from analysis

### DIFF
--- a/client/src/components/SoundCloud/SoundCloudLibrary.jsx
+++ b/client/src/components/SoundCloud/SoundCloudLibrary.jsx
@@ -31,6 +31,13 @@ import {
 // are always visually distinct from Spotify's green (strict source separation).
 const SC_ORANGE = "#ff5500";
 
+// Tracks longer than this are almost certainly DJ sets/mixes — their key/BPM
+// wander across the whole thing, so analyzing them is meaningless. We flag them
+// as "Set" and exclude them from analysis. ~6 min is a heuristic; one constant
+// so it's easy to tune.
+const LIKELY_SET_MS = 6 * 60 * 1000;
+const isLikelySet = (ms) => ms && ms > LIKELY_SET_MS;
+
 const useStyles = makeStyles((theme) => ({
   tile: {
     cursor: "pointer",
@@ -284,8 +291,25 @@ let SoundCloudLibrary = (props) => {
                   </TableCell>
                   <TableCell style={{ fontWeight: 600 }}>{t.title}</TableCell>
                   <TableCell>{t.user && t.user.username}</TableCell>
-                  <TableCell>{t.key_signature || "—"}</TableCell>
-                  <TableCell>{t.bpm || "—"}</TableCell>
+                  {isLikelySet(t.duration) ? (
+                    <TableCell colSpan={2}>
+                      <Chip
+                        size="small"
+                        label="Set · not analyzed"
+                        style={{
+                          backgroundColor: SC_ORANGE,
+                          color: "#fff",
+                          height: 20,
+                          fontWeight: 700,
+                        }}
+                      />
+                    </TableCell>
+                  ) : (
+                    <>
+                      <TableCell>{t.key_signature || "—"}</TableCell>
+                      <TableCell>{t.bpm || "—"}</TableCell>
+                    </>
+                  )}
                   <TableCell>{t.genre || "—"}</TableCell>
                   <TableCell style={{ whiteSpace: "nowrap" }}>
                     {fmtDuration(t.duration)}

--- a/docs/soundcloud-mvp.md
+++ b/docs/soundcloud-mvp.md
@@ -70,6 +70,7 @@ Top-level, **shared across users** (it's analysis of public tracks). Check here 
 
 ### The analysis worker (single FIFO queue)
 Per track:
+0. **Skip likely DJ sets/mixes.** A single track's key/BPM is meaningful; a 60-minute mix's isn't (it wanders across many keys/tempos). So **exclude tracks longer than ~6 minutes** (`LIKELY_SET_MS = 6 * 60 * 1000`) from analysis — never auto-analyze them, skip them in "Analyze Crate," and flag them in the UI as a **"Set"** instead of showing a (meaningless) detected key/BPM. (~6 min is a heuristic; keep the threshold a single constant so it's easy to tune.)
 1. **Cache hit?** `scAnalysis/{urn}` exists → return it. Done.
 2. `GET /tracks/{urn}/streams` → HLS/AAC URL (counts as 1 "play" — fine at personal scale).
 3. **ffmpeg decode** → mono PCM, downsampled (≈22 kHz is plenty for key/BPM). *Optimization: analyze a representative ~60–90s segment (skip intro/outro) for speed.*


### PR DESCRIPTION
Per your note: entire DJ sets/mixes shouldn't be analyzed (their key/BPM wander), and **>~6 min is a good "this is a set" heuristic**.

- Added `LIKELY_SET_MS = 6 * 60 * 1000` (one tunable constant).
- The SoundCloud track table now shows an orange **"Set · not analyzed"** badge for tracks over the threshold, instead of key/BPM cells.
- Recorded the rule in `docs/soundcloud-mvp.md` so the **Phase-1 analysis worker** skips these tracks (no auto-analyze, skipped in "Analyze Crate").

This makes the heuristic visible now and locks the behavior in for when the analysis engine lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)