### PR TITLE
Add the SoundCloud key/BPM analysis microservice

### DIFF
--- a/analysis-service/.dockerignore
+++ b/analysis-service/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.git
+*.md

--- a/analysis-service/.gitignore
+++ b/analysis-service/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/analysis-service/Dockerfile
+++ b/analysis-service/Dockerfile
@@ -1,0 +1,37 @@
+# KeyTrack analysis microservice.
+# Bundles the native audio tools the analysis needs (ffmpeg + bpm-tools, plus
+# libKeyFinder/keyfinder-cli built from source) — none of which install cleanly
+# on Heroku buildpacks, which is exactly why this is its own container.
+FROM node:20-bookworm-slim
+
+# Runtime tools (ffmpeg, bpm-tools) + build deps for libKeyFinder & keyfinder-cli.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ffmpeg bpm-tools \
+      git cmake build-essential ca-certificates \
+      libfftw3-dev \
+      libavcodec-dev libavformat-dev libavutil-dev libswresample-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# libKeyFinder (GPL-3.0) — the key-detection library the Mixxx DJ app maintains.
+RUN git clone --depth 1 https://github.com/mixxxdj/libkeyfinder.git /tmp/lkf \
+ && cmake -S /tmp/lkf -B /tmp/lkf/build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF \
+ && cmake --build /tmp/lkf/build --parallel \
+ && cmake --install /tmp/lkf/build \
+ && ldconfig \
+ && rm -rf /tmp/lkf
+
+# keyfinder-cli (GPL-3.0) — a thin CLI over libKeyFinder. We shell out to it as a
+# separate process, so KeyTrack stays MIT.
+RUN git clone --depth 1 https://github.com/evanpurkhiser/keyfinder-cli.git /tmp/kfc \
+ && c++ -std=c++17 /tmp/kfc/keyfinder_cli.cpp -o /usr/local/bin/keyfinder-cli \
+      -lkeyfinder -lavcodec -lavformat -lavutil -lswresample \
+ && rm -rf /tmp/kfc
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --omit=dev
+COPY . .
+
+ENV PORT=8899
+EXPOSE 8899
+CMD ["node", "server.js"]

--- a/analysis-service/README.md
+++ b/analysis-service/README.md
@@ -1,0 +1,41 @@
+# KeyTrack Analysis Service
+
+A tiny HTTP microservice that computes a track's **musical key (Camelot)** and **BPM** from audio, for KeyTrack's SoundCloud integration (SoundCloud exposes no audio analysis, so we do it ourselves).
+
+It runs **separately** from the main Heroku backend because it needs native audio tools (`ffmpeg`, `bpm-tools`, and `keyfinder-cli`/`libKeyFinder`) that don't install on Heroku buildpacks — they're baked into this service's container instead. The main app calls it over HTTP.
+
+## Engine
+- **Key** — [`keyfinder-cli`](https://github.com/evanpurkhiser/keyfinder-cli) over [`libKeyFinder`](https://github.com/mixxxdj/libkeyfinder) (the Mixxx library), output directly as Camelot.
+- **BPM** — [`bpm-tools`](https://www.pogo.org.uk/~mark/bpm-tools/) on a steady ~90s mid-segment, then **octave-folded** into the octave that fits the track's SoundCloud genre tag (see `bpm.js`).
+- Both are GPL CLIs invoked as **separate processes**, so this service and KeyTrack stay MIT.
+- Tracks longer than ~6 min are treated as DJ sets and skipped (`isLikelySet`).
+
+Benchmarked against Spotify audio-features on 110 same-recording tracks: **BPM 97% correct** (allowing octave; 0.1% median error), **Key 90% harmonically compatible** (55% exact).
+
+## API
+```
+GET  /health                     → { ok: true }
+POST /analyze                    → { isLikelySet, camelot, key, bpm }
+  body: {
+    audioUrl:   string,          // a downloadable audio URL (e.g. SoundCloud http_mp3_128_url)
+    authHeader?: string,         // e.g. "OAuth <token>" for SoundCloud streams
+    durationMs?: number,         // used for the set-exclusion + segment start
+    genre?:     string           // SoundCloud genre tag, used for BPM octave-folding
+  }
+```
+
+## Run locally
+Requires `ffmpeg`, `bpm` (bpm-tools), and a `keyfinder-cli` binary on PATH (or set `KEYFINDER_CLI`, `BPM_BIN`, `FFMPEG`).
+```bash
+npm install
+node server.js          # listens on :8899
+```
+
+## Run with Docker (recommended — bundles all the native tools)
+```bash
+docker build -t keytrack-analysis .
+docker run -p 8899:8899 keytrack-analysis
+```
+
+## Deploy
+Any container host — **Fly.io** (`fly launch` / `fly deploy`) or **Render** (Docker web service). Point the main backend's `ANALYSIS_SERVICE_URL` at it.

--- a/analysis-service/analyze.js
+++ b/analysis-service/analyze.js
@@ -1,0 +1,93 @@
+// The analysis pipeline: audio → key (keyfinder-cli) + BPM (bpm-tools).
+//
+// We shell out to two GPL command-line tools as separate processes (no linking
+// into our code), so this service — and KeyTrack — stay MIT.
+const { execFile, spawn } = require("child_process");
+const { promisify } = require("util");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const execFileP = promisify(execFile);
+
+const { CAMELOT_TO_KEY } = require("./camelot");
+const { octaveFold } = require("./bpm");
+
+// Tracks longer than this are almost certainly DJ sets/mixes — their key/BPM
+// wander, so analysis is meaningless. Mirror the frontend constant.
+const LIKELY_SET_MS = 6 * 60 * 1000;
+// Allow overriding the binary paths for local dev (where keyfinder-cli may be
+// a freshly-built binary rather than on PATH).
+const KEYFINDER = process.env.KEYFINDER_CLI || "keyfinder-cli";
+const BPM_BIN = process.env.BPM_BIN || "bpm";
+const FFMPEG = process.env.FFMPEG || "ffmpeg";
+
+const run = (cmd, args) =>
+  execFileP(cmd, args, { maxBuffer: 1 << 26 }).then((r) => r.stdout.trim());
+
+// Decode to mono 44.1k WAV + a steady ~90s mid-segment (start at 25% in).
+async function decode(input, durationMs, dir) {
+  const wav = path.join(dir, "a.wav");
+  const seg = path.join(dir, "seg.wav");
+  await run(FFMPEG, ["-y", "-i", input, "-ac", "1", "-ar", "44100", wav]);
+  const start = Math.max(20, Math.floor(((durationMs || 0) / 1000) * 0.25));
+  await run(FFMPEG, ["-y", "-ss", String(start), "-t", "90", "-i", wav, "-ac", "1", seg]).catch(
+    () => {}
+  );
+  return { wav, seg: fs.existsSync(seg) ? seg : wav };
+}
+
+async function detectKey(wav) {
+  const camelot = await run(KEYFINDER, ["-n", "camelot", wav]).catch(() => null);
+  return { camelot: camelot || null, key: (camelot && CAMELOT_TO_KEY[camelot]) || null };
+}
+
+// bpm-tools reads raw float samples from stdin — pipe ffmpeg's PCM into it.
+function detectBpm(seg, genre) {
+  return new Promise((resolve) => {
+    const ff = spawn(FFMPEG, ["-v", "quiet", "-i", seg, "-f", "f32le", "-ar", "44100", "-ac", "1", "-"]);
+    const bpm = spawn(BPM_BIN, ["-m", "70", "-x", "180"]);
+    let out = "";
+    ff.stdout.pipe(bpm.stdin);
+    bpm.stdout.on("data", (d) => (out += d));
+    ff.on("error", () => {});
+    bpm.on("error", () => resolve(null));
+    bpm.on("close", () => {
+      const raw = parseFloat(out);
+      resolve(raw ? octaveFold(raw, genre) : null);
+    });
+  });
+}
+
+// Analyze a local audio file path.
+async function analyzeFile(input, { durationMs, genre } = {}) {
+  if (durationMs && durationMs > LIKELY_SET_MS) return { isLikelySet: true };
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kt-an-"));
+  try {
+    const { wav, seg } = await decode(input, durationMs, dir);
+    const [key, bpm] = await Promise.all([detectKey(wav), detectBpm(seg, genre)]);
+    return { isLikelySet: false, camelot: key.camelot, key: key.key, bpm };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// Analyze a remote audio URL (downloads first, with an optional auth header —
+// SoundCloud stream URLs need `Authorization: OAuth <token>`).
+async function analyzeUrl(audioUrl, { authHeader, durationMs, genre } = {}) {
+  if (durationMs && durationMs > LIKELY_SET_MS) return { isLikelySet: true };
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kt-an-"));
+  const file = path.join(dir, "in.audio");
+  try {
+    const res = await fetch(audioUrl, {
+      headers: authHeader ? { Authorization: authHeader } : {},
+      redirect: "follow",
+    });
+    if (!res.ok) throw new Error("download failed " + res.status);
+    fs.writeFileSync(file, Buffer.from(await res.arrayBuffer()));
+    return await analyzeFile(file, { durationMs, genre });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+module.exports = { analyzeFile, analyzeUrl, LIKELY_SET_MS };

--- a/analysis-service/bpm.js
+++ b/analysis-service/bpm.js
@@ -1,0 +1,69 @@
+// BPM octave/metric correction.
+//
+// Beat trackers reliably find the *period* but often pick the wrong octave
+// (½, ⅔, etc.) of the true tempo — every error is a clean ratio. We resolve
+// the octave using the track's SoundCloud genre tag: each genre sits in a
+// known tempo band, so we fold the detected value into the octave that lands
+// in that band. Conservative on purpose: if the raw value is already plausible
+// for the genre, we leave it alone (the benchmark showed raw detection is
+// already ~82% exact — don't break what's right).
+
+// genre substring(s) → [minBPM, maxBPM]
+const GENRE_BANDS = [
+  [["drum & bass", "drum and bass", "dnb", "d&b", "neurofunk", "liquid funk"], [165, 185]],
+  [["drumstep"], [160, 180]],
+  [["hardstyle", "hardcore", "rawstyle", "frenchcore", "uptempo"], [145, 185]],
+  [["dubstep", "riddim", "brostep", "tearout"], [135, 150]],
+  [["future bass", "melodic bass", "melodic dubstep", "future", "melodic"], [140, 165]],
+  [["trap", "phonk"], [140, 175]],
+  [["psytrance"], [140, 150]],
+  [["trance", "uplifting", "progressive trance"], [130, 145]],
+  [["techno", "tech house", "tech-house", "minimal"], [122, 138]],
+  [["garage", "ukg", "2-step", "speed garage"], [128, 142]],
+  [["house", "deep house", "bass house", "progressive house", "electro house", "big room", "g-house", "future house"], [120, 132]],
+  [["disco", "funk", "nu disco"], [110, 125]],
+  [["hip hop", "hip-hop", "rap", "r&b", "rnb"], [80, 110]],
+  // generic / wide → weak hint, rarely used
+  [["dance", "edm", "electronic", "pop"], [100, 160]],
+];
+
+const FOLD_FACTORS = [1, 0.5, 2, 1.5, 2 / 3, 0.75, 4 / 3, 3, 1 / 3];
+
+function genreBand(genre) {
+  if (!genre) return null;
+  const g = String(genre).toLowerCase();
+  for (const [keys, band] of GENRE_BANDS) {
+    if (keys.some((k) => g.includes(k))) return band;
+  }
+  return null;
+}
+
+// Fold `raw` BPM toward the genre's tempo band. Returns a rounded integer.
+function octaveFold(raw, genre) {
+  if (!raw || isNaN(raw)) return null;
+  const band = genreBand(genre);
+  if (!band) {
+    // No usable genre hint: only nudge clearly-out-of-range values into a
+    // broad perceptual window so we never report something absurd.
+    let b = raw;
+    while (b < 80) b *= 2;
+    while (b > 185) b /= 2;
+    return Math.round(b);
+  }
+  const [lo, hi] = band;
+  // Already plausible for the genre → trust the detector, don't touch it.
+  if (raw >= lo && raw <= hi) return Math.round(raw);
+  // Otherwise pick the octave multiple that lands inside the band (closest to
+  // its center). If none lands cleanly, leave the detected value as-is.
+  const center = (lo + hi) / 2;
+  let best = null;
+  for (const f of FOLD_FACTORS) {
+    const v = raw * f;
+    if (v >= lo && v <= hi && (best === null || Math.abs(v - center) < Math.abs(best - center))) {
+      best = v;
+    }
+  }
+  return Math.round(best === null ? raw : best);
+}
+
+module.exports = { octaveFold, genreBand };

--- a/analysis-service/camelot.js
+++ b/analysis-service/camelot.js
@@ -1,0 +1,12 @@
+// Camelot code → readable musical key, so we don't have to run keyfinder twice
+// (it already gives us the Camelot code directly).
+const CAMELOT_TO_KEY = {
+  "8B": "C", "3B": "D♭", "10B": "D", "5B": "E♭", "12B": "E",
+  "7B": "F", "2B": "G♭", "9B": "G", "4B": "A♭", "11B": "A",
+  "6B": "B♭", "1B": "B",
+  "5A": "Cm", "12A": "C♯m", "7A": "Dm", "2A": "E♭m", "9A": "Em",
+  "4A": "Fm", "11A": "F♯m", "6A": "Gm", "1A": "A♭m", "8A": "Am",
+  "3A": "B♭m", "10A": "Bm",
+};
+
+module.exports = { CAMELOT_TO_KEY };

--- a/analysis-service/package-lock.json
+++ b/analysis-service/package-lock.json
@@ -1,0 +1,828 @@
+{
+  "name": "keytrack-analysis-service",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "keytrack-analysis-service",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "express": "^4.18.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/analysis-service/package.json
+++ b/analysis-service/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "keytrack-analysis-service",
+  "version": "1.0.0",
+  "description": "Key + BPM analysis microservice (libKeyFinder + bpm-tools) for KeyTrack's SoundCloud integration.",
+  "license": "MIT",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/analysis-service/server.js
+++ b/analysis-service/server.js
@@ -1,0 +1,28 @@
+// KeyTrack analysis microservice.
+// POST /analyze { audioUrl, authHeader?, durationMs?, genre? }
+//   → { isLikelySet, camelot, key, bpm }
+// Runs separately from the main backend (it needs ffmpeg + keyfinder-cli +
+// bpm-tools, which live in this service's container). The main app calls it
+// over HTTP.
+const express = require("express");
+const { analyzeUrl } = require("./analyze");
+
+const app = express();
+app.use(express.json({ limit: "256kb" }));
+
+app.get("/health", (_req, res) => res.send({ ok: true }));
+
+app.post("/analyze", async (req, res) => {
+  const { audioUrl, authHeader, durationMs, genre } = req.body || {};
+  if (!audioUrl) return res.status(400).send({ error: "audioUrl required" });
+  try {
+    const result = await analyzeUrl(audioUrl, { authHeader, durationMs, genre });
+    res.send(result);
+  } catch (e) {
+    console.error("analyze failed:", e.message);
+    res.status(500).send({ error: "analysis_failed" });
+  }
+});
+
+const PORT = process.env.PORT || 8899;
+app.listen(PORT, () => console.log("analysis service listening on " + PORT));

--- a/docs/soundcloud-mvp.md
+++ b/docs/soundcloud-mvp.md
@@ -73,13 +73,20 @@ Per track:
 0. **Skip likely DJ sets/mixes.** A single track's key/BPM is meaningful; a 60-minute mix's isn't (it wanders across many keys/tempos). So **exclude tracks longer than ~6 minutes** (`LIKELY_SET_MS = 6 * 60 * 1000`) from analysis — never auto-analyze them, skip them in "Analyze Crate," and flag them in the UI as a **"Set"** instead of showing a (meaningless) detected key/BPM. (~6 min is a heuristic; keep the threshold a single constant so it's easy to tune.)
 1. **Cache hit?** `scAnalysis/{urn}` exists → return it. Done.
 2. `GET /tracks/{urn}/streams` → HLS/AAC URL (counts as 1 "play" — fine at personal scale).
-3. **ffmpeg decode** → mono PCM, downsampled (≈22 kHz is plenty for key/BPM). *Optimization: analyze a representative ~60–90s segment (skip intro/outro) for speed.*
-4. **libKeyFinder** → key; **JS BPM lib** (web-audio-beat-detector / realtime-bpm-analyzer) → BPM.
-5. **Normalize**: key → Camelot (reuse `utils/harmonic.js` mapping); BPM range-constrain + half/double-time correct.
+3. **ffmpeg decode** → mono WAV. *Analyze a representative ~90s mid-segment (start at 25% of the track) for BPM — faster and more stable than the whole track.*
+4. **`keyfinder-cli`** (libKeyFinder, `-n camelot`) → key; **`bpm-tools`** (`bpm`) on the segment → BPM. Both are GPL CLIs we shell out to (separate processes → KeyTrack stays MIT). ~1.5s/track.
+5. **Normalize / correct**: key already comes out as Camelot. **BPM octave-fold** into the octave that fits the track's SoundCloud `genre` tag's tempo band (DnB ≈170–180, house ≈124–128, future/melodic bass ≈140–160…); a rare residual gets a one-tap ×2/÷2 fallback in the UI.
 6. **Write** `scAnalysis/{urn}` and return.
 
 - **Concurrency = 1** for MVP; subsequent requests queue. (Matches your spec: finish the current, queue the next.)
-- **Async, never blocks**: HTTP returns `queued` immediately; frontend polls. (Heroku 30s request cap → the queue runs off the request cycle.)
+- **Async, never blocks**: HTTP returns `queued` immediately; frontend polls.
+- **Host: a containerized analysis microservice** (Fly.io/Render). ffmpeg + libkeyfinder + bpm-tools install cleanly in Linux and keyfinder-cli builds in the Dockerfile; the existing Heroku OAuth/proxy backend is untouched and calls this service over HTTP. (Spike built keyfinder-cli from the `libkeyfinder` source with one clang++ command — no cmake.)
+
+### 📊 Benchmark (validated 2026-06): keyfinder-cli + bpm-tools vs. Spotify
+110 same-recording tracks (the "Bass Lounge" Spotify playlist, matched to the same upload on SoundCloud), compared against Spotify's audio-features:
+- **BPM** — 82% exact (≤3%), **97% correct allowing a clean octave** (auto-fixable), **0.1% median error** after octave-fold, ~3% genuinely off. → as good as Spotify.
+- **KEY** — 55% exact agreement, **90% harmonically compatible** (exact/relative/fifth), ~99% within one Camelot step, ~1% truly wrong. (Spotify isn't ground truth — it errs too.)
+- **Verdict:** ship this stack. Essentia-`edma` is a future A/B *only if* we want to raise the exact-key number; not worth the AGPL container now.
 
 ### Backend endpoints
 - `POST /soundcloud/analyze` `{ trackUrn }` → `{ status: 'cached'|'queued', analysis? }`


### PR DESCRIPTION
The analysis engine, validated by the spike + 110-track benchmark, as a standalone containerized service (`analysis-service/`).

## What
A small HTTP service that turns audio → **Camelot key + BPM**:
- **Key** — `keyfinder-cli` over `libKeyFinder` (Mixxx's library), output directly as Camelot.
- **BPM** — `bpm-tools` on a steady ~90s mid-segment, then **octave-folded** into the octave that fits the track's SoundCloud genre tag.
- Both are GPL CLIs shelled out as **separate processes** → KeyTrack stays MIT.
- Skips likely DJ sets (>6 min → `isLikelySet`).

```
POST /analyze { audioUrl, authHeader?, durationMs?, genre? } → { isLikelySet, camelot, key, bpm }
```

## Why a separate container
`ffmpeg` + `bpm-tools` + `keyfinder-cli`/`libKeyFinder` don't install on Heroku buildpacks. The **Dockerfile** bakes them in (builds libKeyFinder + keyfinder-cli from source). Deploy to **Fly.io/Render**; the Heroku backend stays untouched and calls this over HTTP.

## Benchmark (recorded in the spec)
110 same-recording tracks vs Spotify audio-features: **BPM 82% exact / 97% octave-correct** (0.1% median error), **Key 55% exact / 90% harmonically compatible**.

## Verified locally
Pipeline returns sane key/BPM on a real track; genre-fold corrects octave errors (116 DnB → 174); `/health` 200, validation 400, deps clean. *(The Docker image build itself should be validated on first deploy — it compiles libKeyFinder, which I couldn't run here without Docker.)*

Next: wire the main backend's `/streams` route + an `ANALYSIS_SERVICE_URL` call, the `scAnalysis` Firestore cache, and the analyze-on-play queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)