### PR TITLE
Backend /soundcloud/analyze route → analysis service

### DIFF
--- a/local-server/.env.example
+++ b/local-server/.env.example
@@ -16,3 +16,9 @@ SPOTIFY_SECRET=your_spotify_client_secret
 #   https://key-track2.herokuapp.com/soundcloud/callback )
 SOUNDCLOUD_ID=your_soundcloud_client_id
 SOUNDCLOUD_SECRET=your_soundcloud_client_secret
+
+# --- Analysis microservice ---
+# Where the key/BPM analysis service runs. Defaults to localhost for dev (run
+# `cd analysis-service && node server.js`). In prod, point at the deployed
+# Fly.io/Render URL.
+# ANALYSIS_SERVICE_URL=http://127.0.0.1:8899

--- a/local-server/index.js
+++ b/local-server/index.js
@@ -463,5 +463,67 @@ app.get(
   })
 );
 
+// ---------------------------------------------------------------------------
+// SoundCloud key/BPM analysis
+//
+// SoundCloud has no audio-analysis API, so we compute it ourselves: resolve the
+// track's stream URL, then hand it (with the user's token) to the analysis
+// microservice, which downloads + decodes + runs keyfinder-cli + bpm-tools.
+// The service is a separate container; in dev it runs on localhost:8899.
+// ---------------------------------------------------------------------------
+const ANALYSIS_SERVICE_URL =
+  process.env.ANALYSIS_SERVICE_URL || 'http://127.0.0.1:8899';
+const LIKELY_SET_MS = 6 * 60 * 1000;
+
+app.get(
+  '/soundcloud/analyze',
+  scRoute((req, res, token) => {
+    const trackId = req.query.track_id || req.query.urn;
+    const durationMs = req.query.duration ? Number(req.query.duration) : 0;
+    const genre = req.query.genre || '';
+    if (!trackId) return res.status(400).send({ error: 'track_id required' });
+    // Skip likely DJ sets without touching the stream/quota.
+    if (durationMs && durationMs > LIKELY_SET_MS) {
+      return res.send({ isLikelySet: true });
+    }
+    // 1) resolve the playable stream URL
+    request.get(
+      {
+        url: SC_API + '/tracks/' + encodeURIComponent(trackId) + '/streams',
+        headers: { Authorization: 'OAuth ' + token, accept: 'application/json' },
+        json: true,
+      },
+      function (err, r, streams) {
+        if (err || !streams) {
+          return res.status(502).send({ error: 'stream_lookup_failed' });
+        }
+        const audioUrl =
+          streams.http_mp3_128_url || streams.hls_aac_160_url || null;
+        if (!audioUrl) return res.status(422).send({ error: 'no_stream' });
+        // 2) hand it to the analysis service
+        request.post(
+          {
+            url: ANALYSIS_SERVICE_URL + '/analyze',
+            json: {
+              audioUrl,
+              authHeader: 'OAuth ' + token,
+              durationMs,
+              genre,
+            },
+            timeout: 60000,
+          },
+          function (e2, r2, result) {
+            if (e2 || !r2 || r2.statusCode !== 200) {
+              console.error('analysis service error', e2 && e2.message, r2 && r2.statusCode);
+              return res.status(502).send({ error: 'analysis_failed' });
+            }
+            res.send(result);
+          }
+        );
+      }
+    );
+  })
+);
+
 console.log('Listening on 8888');
 app.listen(process.env.PORT || 8888);


### PR DESCRIPTION
Wires the main backend to the analysis microservice (#66).

`GET /soundcloud/analyze?track_id=&duration=&genre=` (with the SC token):
1. Skips likely DJ sets (>6 min) up front.
2. Resolves the track's playable stream URL (`/tracks/:id/streams`).
3. Hands `{ audioUrl, authHeader: 'OAuth <token>', durationMs, genre }` to the analysis service (`ANALYSIS_SERVICE_URL`, default `localhost:8899`).
4. Returns `{ camelot, key, bpm, isLikelySet }`.

Verified the route's auth (401) + validation (400) guards with both services running locally. Full key/BPM round-trip gets exercised when the frontend queue lands next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)