### PR TITLE
Analyze-on-play + Analyze Crate with live key/BPM fill (Phase 1 frontend)

### DIFF
--- a/client/src/components/SoundCloud/SoundCloudLibrary.jsx
+++ b/client/src/components/SoundCloud/SoundCloudLibrary.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import {
   Avatar,
   Box,
+  Button,
   Card,
   CardContent,
   Chip,
@@ -26,7 +27,11 @@ import {
   ArrowBack,
   OpenInNew,
   PlayArrow,
+  GraphicEq,
 } from "@material-ui/icons";
+
+import { camelotColor } from "../../utils/harmonic";
+import { getScAnalysis, saveScAnalysis } from "../../utils/scAnalysis";
 
 // SoundCloud's brand orange — used for the source badge so SoundCloud crates
 // are always visually distinct from Spotify's green (strict source separation).
@@ -114,6 +119,11 @@ let SoundCloudLibrary = (props) => {
   const [tracks, setTracks] = React.useState(null);
   // The track currently loaded into the embedded SoundCloud Widget player.
   const [playing, setPlaying] = React.useState(null);
+  // Our computed key/BPM per track URN: { status:'loading' } | result.
+  const [analysis, setAnalysis] = React.useState({});
+  const queueRef = React.useRef([]); // FIFO of tracks awaiting analysis
+  const seenRef = React.useRef(new Set()); // urns already queued/done (dedupe)
+  const processingRef = React.useRef(false);
 
   // Call the backend proxy with the SoundCloud token. On a 401 (expired access
   // token) refresh once and retry, mirroring the Spotify session handling.
@@ -139,6 +149,69 @@ let SoundCloudLibrary = (props) => {
     },
     [props]
   );
+
+  // --- Key/BPM analysis: a single-worker FIFO queue. Enqueuing never blocks
+  // (playback is independent); results fill in live and cache to Firestore so a
+  // track is only ever analyzed once for the whole app.
+  const trackUrn = (t) => t.urn || String(t.id);
+
+  const processQueue = React.useCallback(() => {
+    if (processingRef.current) return;
+    processingRef.current = true;
+    (async () => {
+      while (queueRef.current.length) {
+        const t = queueRef.current.shift();
+        const urn = trackUrn(t);
+        let result = await getScAnalysis(urn); // shared cache first
+        if (!result) {
+          try {
+            const tid = t.id || t.urn;
+            result = await scFetch(
+              `/soundcloud/analyze?track_id=${encodeURIComponent(tid)}` +
+                `&duration=${t.duration || 0}` +
+                `&genre=${encodeURIComponent(t.genre || "")}`
+            );
+            if (result && !result.isLikelySet && result.camelot) {
+              saveScAnalysis(urn, result);
+            }
+          } catch (e) {
+            result = { error: true };
+          }
+        }
+        setAnalysis((a) => ({ ...a, [urn]: result || { error: true } }));
+        // Failed (e.g. HLS-only / no progressive stream) → allow a retry later.
+        if (!result || result.error || (!result.camelot && !result.isLikelySet)) {
+          seenRef.current.delete(urn);
+        }
+      }
+      processingRef.current = false;
+    })();
+  }, [scFetch]);
+
+  const enqueueAnalysis = React.useCallback(
+    (t) => {
+      const urn = trackUrn(t);
+      if (seenRef.current.has(urn)) return; // already queued/done
+      seenRef.current.add(urn);
+      if (isLikelySet(t.duration)) {
+        setAnalysis((a) => ({ ...a, [urn]: { isLikelySet: true } }));
+        return;
+      }
+      setAnalysis((a) => ({ ...a, [urn]: { status: "loading" } }));
+      queueRef.current.push(t);
+      processQueue();
+    },
+    [processQueue]
+  );
+
+  // Play a track → load the Widget AND kick off analysis (non-blocking).
+  const playTrack = (t) => {
+    setPlaying(t);
+    enqueueAnalysis(t);
+  };
+
+  // "Analyze Crate" → enqueue every track in the open crate.
+  const analyzeCrate = () => (tracks || []).forEach((t) => enqueueAnalysis(t));
 
   // Open a crate → fetch its tracks. Likes/reposts have their own endpoints;
   // a playlist's tracks come from /playlists/:urn/tracks.
@@ -279,6 +352,18 @@ let SoundCloudLibrary = (props) => {
           <Typography variant="caption" color="textSecondary">
             {opened.count} tracks
           </Typography>
+          <Box style={{ flex: 1 }} />
+          {tracks && tracks.length > 0 && (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<GraphicEq />}
+              onClick={analyzeCrate}
+              style={{ textTransform: "none", borderRadius: 8, borderColor: SC_ORANGE, color: SC_ORANGE }}
+            >
+              Analyze crate
+            </Button>
+          )}
         </Box>
 
         {playing && (
@@ -322,6 +407,7 @@ let SoundCloudLibrary = (props) => {
               {tracks.map((t) => {
                 const tid = t.urn || t.id;
                 const isPlaying = playing && (playing.urn || playing.id) === tid;
+                const a = analysis[tid];
                 return (
                 <TableRow
                   key={tid}
@@ -333,8 +419,8 @@ let SoundCloudLibrary = (props) => {
                   <TableCell style={{ width: 48 }}>
                     <IconButton
                       size="small"
-                      onClick={() => setPlaying(t)}
-                      title="Play on SoundCloud"
+                      onClick={() => playTrack(t)}
+                      title="Play + analyze"
                       style={{ padding: 2 }}
                     >
                       <Box style={{ position: "relative" }}>
@@ -366,7 +452,7 @@ let SoundCloudLibrary = (props) => {
                   </TableCell>
                   <TableCell style={{ fontWeight: 600 }}>{t.title}</TableCell>
                   <TableCell>{t.user && t.user.username}</TableCell>
-                  {isLikelySet(t.duration) ? (
+                  {isLikelySet(t.duration) || (a && a.isLikelySet) ? (
                     <TableCell colSpan={2}>
                       <Chip
                         size="small"
@@ -379,6 +465,41 @@ let SoundCloudLibrary = (props) => {
                         }}
                       />
                     </TableCell>
+                  ) : a && a.status === "loading" ? (
+                    <TableCell colSpan={2}>
+                      <span
+                        style={{
+                          display: "inline-flex",
+                          alignItems: "center",
+                          gap: 6,
+                          color: "#888",
+                        }}
+                      >
+                        <CircularProgress size={13} style={{ color: SC_ORANGE }} />
+                        analyzing…
+                      </span>
+                    </TableCell>
+                  ) : a && a.camelot ? (
+                    <>
+                      <TableCell>
+                        <span
+                          style={{
+                            backgroundColor: camelotColor(a.camelot).bg,
+                            color: camelotColor(a.camelot).text,
+                            padding: "3px 8px",
+                            borderRadius: 10,
+                            fontWeight: 600,
+                            fontSize: "0.8rem",
+                            whiteSpace: "nowrap",
+                          }}
+                          title="Detected by KeyTrack"
+                        >
+                          {a.camelot}
+                          {a.key ? " · " + a.key : ""}
+                        </span>
+                      </TableCell>
+                      <TableCell>{a.bpm || "—"}</TableCell>
+                    </>
                   ) : (
                     <>
                       <TableCell>{t.key_signature || "—"}</TableCell>
@@ -412,8 +533,9 @@ let SoundCloudLibrary = (props) => {
           color="textSecondary"
           style={{ display: "block", marginTop: 12 }}
         >
-          Key &amp; BPM are artist-entered (usually blank) — KeyTrack analysis
-          comes next. Tracks link out to SoundCloud (source &amp; attribution).
+          Play a track or hit <b>Analyze crate</b> to compute its key + BPM with
+          KeyTrack (SoundCloud has none). Colored keys are ours; plain values are
+          artist-entered. Tracks link out to SoundCloud (source &amp; attribution).
         </Typography>
       </Box>
     );

--- a/client/src/utils/scAnalysis.js
+++ b/client/src/utils/scAnalysis.js
@@ -1,0 +1,37 @@
+import { getFirestore, doc, getDoc, setDoc } from "firebase/firestore";
+
+// Shared cache of our computed SoundCloud key/BPM, keyed by track URN and
+// shared across all users (it's analysis of public tracks). A track is only
+// ever analyzed once for the whole app — everyone reuses the result, and it
+// never re-spends the play quota. Mirrors crateMeta.js (relies on the Firebase
+// app initialized in Playlist.jsx; no Firebase Auth).
+//
+// Bump ENGINE_VERSION to invalidate every cached analysis if the engine
+// changes (so old/worse results get recomputed).
+const ENGINE_VERSION = 1;
+
+// Firestore doc ids can't contain "/" — urns look like "soundcloud:tracks:123".
+const keyId = (urn) => String(urn).replace(/[:/]/g, "_");
+
+export async function getScAnalysis(urn) {
+  try {
+    const snap = await getDoc(doc(getFirestore(), "scAnalysis", keyId(urn)));
+    const d = snap.exists() ? snap.data() : null;
+    return d && d.engineVersion === ENGINE_VERSION ? d : null;
+  } catch (e) {
+    return null; // offline / rules / not-initialized → just skip the cache
+  }
+}
+
+export async function saveScAnalysis(urn, data) {
+  try {
+    await setDoc(doc(getFirestore(), "scAnalysis", keyId(urn)), {
+      ...data,
+      urn,
+      engineVersion: ENGINE_VERSION,
+      analyzedAt: Date.now(),
+    });
+  } catch (e) {
+    console.error("saveScAnalysis failed", e);
+  }
+}

--- a/local-server/.env.example
+++ b/local-server/.env.example
@@ -16,3 +16,9 @@ SPOTIFY_SECRET=your_spotify_client_secret
 #   https://key-track2.herokuapp.com/soundcloud/callback )
 SOUNDCLOUD_ID=your_soundcloud_client_id
 SOUNDCLOUD_SECRET=your_soundcloud_client_secret
+
+# --- Analysis microservice ---
+# Where the key/BPM analysis service runs. Defaults to localhost for dev (run
+# `cd analysis-service && node server.js`). In prod, point at the deployed
+# Fly.io/Render URL.
+# ANALYSIS_SERVICE_URL=http://127.0.0.1:8899

--- a/local-server/index.js
+++ b/local-server/index.js
@@ -463,5 +463,67 @@ app.get(
   })
 );
 
+// ---------------------------------------------------------------------------
+// SoundCloud key/BPM analysis
+//
+// SoundCloud has no audio-analysis API, so we compute it ourselves: resolve the
+// track's stream URL, then hand it (with the user's token) to the analysis
+// microservice, which downloads + decodes + runs keyfinder-cli + bpm-tools.
+// The service is a separate container; in dev it runs on localhost:8899.
+// ---------------------------------------------------------------------------
+const ANALYSIS_SERVICE_URL =
+  process.env.ANALYSIS_SERVICE_URL || 'http://127.0.0.1:8899';
+const LIKELY_SET_MS = 6 * 60 * 1000;
+
+app.get(
+  '/soundcloud/analyze',
+  scRoute((req, res, token) => {
+    const trackId = req.query.track_id || req.query.urn;
+    const durationMs = req.query.duration ? Number(req.query.duration) : 0;
+    const genre = req.query.genre || '';
+    if (!trackId) return res.status(400).send({ error: 'track_id required' });
+    // Skip likely DJ sets without touching the stream/quota.
+    if (durationMs && durationMs > LIKELY_SET_MS) {
+      return res.send({ isLikelySet: true });
+    }
+    // 1) resolve the playable stream URL
+    request.get(
+      {
+        url: SC_API + '/tracks/' + encodeURIComponent(trackId) + '/streams',
+        headers: { Authorization: 'OAuth ' + token, accept: 'application/json' },
+        json: true,
+      },
+      function (err, r, streams) {
+        if (err || !streams) {
+          return res.status(502).send({ error: 'stream_lookup_failed' });
+        }
+        const audioUrl =
+          streams.http_mp3_128_url || streams.hls_aac_160_url || null;
+        if (!audioUrl) return res.status(422).send({ error: 'no_stream' });
+        // 2) hand it to the analysis service
+        request.post(
+          {
+            url: ANALYSIS_SERVICE_URL + '/analyze',
+            json: {
+              audioUrl,
+              authHeader: 'OAuth ' + token,
+              durationMs,
+              genre,
+            },
+            timeout: 60000,
+          },
+          function (e2, r2, result) {
+            if (e2 || !r2 || r2.statusCode !== 200) {
+              console.error('analysis service error', e2 && e2.message, r2 && r2.statusCode);
+              return res.status(502).send({ error: 'analysis_failed' });
+            }
+            res.send(result);
+          }
+        );
+      }
+    );
+  })
+);
+
 console.log('Listening on 8888');
 app.listen(process.env.PORT || 8888);


### PR DESCRIPTION
The Phase-1 payoff: **play a SoundCloud track → its key + BPM compute and fill in live.** ✅ Verified working — colored Camelot chips + sensible BPMs across a real crate.

> **Stacked on #67** (the backend `/soundcloud/analyze` route). Merge #67 first, or merge this (it includes #67).

## What
- A **single-worker FIFO queue** in `SoundCloudLibrary`: playing a track (or **"Analyze crate"**) enqueues it; the worker calls `/soundcloud/analyze`, fills the **Key/BPM cells live** (colored Camelot chip + BPM = our values), and **caches to Firestore** (`scAnalysis/{urn}`, shared across users → analyzed once for everyone, never re-spends the play quota).
- **Sets (>6 min)** flagged and skipped; failures (e.g. **HLS-only** tracks with no progressive stream) show "—" and retry on next play.
- New `client/src/utils/scAnalysis.js` cache helper.

## Known follow-up
A few tracks are **HLS-only** (no progressive MP3) → the analysis service's download-then-decode can't handle them yet (they show "—"). Fix is to decode HLS directly via ffmpeg with auth'd segments — a follow-up on the analysis service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)