### PR TITLE
Load + paginate tracks inside a SoundCloud crate

### DIFF
--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -333,6 +333,9 @@ function normalizeSoundcloudCrate(c) {
     // Non-set track count (null = not yet known). Used to hide all-set crates
     // when "Disable Sets" is on.
     nonSetCount: c.nonSetCount == null ? null : c.nonSetCount,
+    // True when the tile count is a first-page floor (likes/reposts) — the full
+    // list still loads when the crate is opened.
+    more: !!c.more,
     ownerName: c.owner || "",
     description: "",
     raw: c,
@@ -1066,7 +1069,7 @@ let PLLibrary = (props) => {
           )}
           <Box className={classes.tileMeta}>
             <Chip
-              label={`${displayCount} tracks`}
+              label={`${displayCount}${crate.more ? "+" : ""} tracks`}
               size="small"
               className={classes.trackChip}
               style={{ backgroundColor: accent }}

--- a/client/src/components/SoundCloud/SoundCloudCrate.jsx
+++ b/client/src/components/SoundCloud/SoundCloudCrate.jsx
@@ -31,6 +31,7 @@ import {
 
 import { camelotColor } from "../../utils/harmonic";
 import { getScAnalysis, saveScAnalysis } from "../../utils/scAnalysis";
+import { fetchScTracks } from "../../utils/soundcloudCrates";
 
 // SoundCloud's brand orange — keeps SoundCloud crates visually distinct from
 // Spotify's green (strict source separation).
@@ -193,10 +194,9 @@ let SoundCloudCrate = (props) => {
         : "/soundcloud/playlists/" + encodeURIComponent(crate.id) + "/tracks";
     (async () => {
       try {
-        const data = await scFetch(path);
-        const list = data && data.collection ? data.collection : Array.isArray(data) ? data : [];
-        // Likes/reposts come back as { track: {...} } wrappers on some endpoints.
-        if (!cancelled) setTracks(list.map((t) => (t && t.track ? t.track : t)).filter(Boolean));
+        // Follow pagination so the whole crate loads, not just the first 50.
+        const list = await fetchScTracks(scFetch, path);
+        if (!cancelled) setTracks(list);
       } catch (e) {
         console.error("Failed to load SoundCloud crate", e);
         if (!cancelled) setTracks([]);

--- a/client/src/components/SoundCloud/SoundCloudCrate.jsx
+++ b/client/src/components/SoundCloud/SoundCloudCrate.jsx
@@ -16,6 +16,7 @@ import {
   TableHead,
   TableRow,
   TableSortLabel,
+  TablePagination,
   Typography,
   withStyles,
 } from "@material-ui/core";
@@ -89,6 +90,9 @@ let SoundCloudCrate = (props) => {
   // Within-crate search + column sort (parity with the Spotify track table).
   const [search, setSearch] = React.useState("");
   const [sort, setSort] = React.useState({ col: null, dir: "asc" });
+  // Render only the current page of rows (parity with the Spotify track view).
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(100);
 
   // Call the backend proxy with the SoundCloud token. On a 401 (expired access
   // token) refresh once and retry, mirroring the Spotify session handling.
@@ -280,6 +284,13 @@ let SoundCloudCrate = (props) => {
         : { col, dir: "asc" }
     );
 
+  // Only the current page is rendered into the DOM (search/sort still run over
+  // the whole crate). Snap back to page 1 whenever the result set changes.
+  React.useEffect(() => {
+    setPage(0);
+  }, [search, sort, props.hideSets, crate]);
+  const pagedView = view.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
+
   return (
     // paddingBottom clears the fixed bottom player bar so the last rows /
     // footer note aren't hidden behind it inside the full-screen modal.
@@ -422,7 +433,7 @@ let SoundCloudCrate = (props) => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {view.map((t) => {
+            {pagedView.map((t) => {
               const tid = t.urn || t.id;
               const isPlaying = playing && (playing.urn || playing.id) === tid;
               const a = analysis[tid];
@@ -544,6 +555,22 @@ let SoundCloudCrate = (props) => {
             })}
           </TableBody>
         </Table>
+      )}
+
+      {tracks && view.length > 50 && (
+        <TablePagination
+          component="div"
+          count={view.length}
+          page={page}
+          onChangePage={(e, p) => setPage(p)}
+          rowsPerPage={rowsPerPage}
+          onChangeRowsPerPage={(e) => {
+            setRowsPerPage(parseInt(e.target.value, 10));
+            setPage(0);
+          }}
+          rowsPerPageOptions={[50, 100, 200]}
+          labelRowsPerPage="Tracks per page"
+        />
       )}
 
       <Typography

--- a/client/src/utils/soundcloudCrates.js
+++ b/client/src/utils/soundcloudCrates.js
@@ -66,6 +66,13 @@ async function fetchAllPages(scFetch, path) {
   return items;
 }
 
+// Load a crate's FULL track list (all pages), normalizing { track: {...} }
+// wrappers (likes/reposts return those) into plain track objects.
+export async function fetchScTracks(scFetch, path) {
+  const items = await fetchAllPages(scFetch, path);
+  return items.map((t) => (t && t.track ? t.track : t)).filter(Boolean);
+}
+
 // Fetch the user's SoundCloud crates: Liked Tracks + Reposts as virtual crates
 // (artwork from the first track) plus their playlists/sets. Returns a plain
 // array of crate descriptors:
@@ -92,6 +99,9 @@ export async function fetchSoundcloudCrates(scFetch) {
       name: "Liked Tracks",
       owner: "Your likes",
       count: likeTracks.length,
+      // We only fetch the first page for the tile; there may be more (the full
+      // list loads when the crate is opened).
+      more: !!(likes && likes.next_href),
       nonSetCount: countNonSets(likeTracks),
       artwork: bigArtwork(likeTracks[0] && likeTracks[0].artwork_url),
     });
@@ -103,6 +113,7 @@ export async function fetchSoundcloudCrates(scFetch) {
       name: "Reposts",
       owner: "Your reposts",
       count: repostTracks.length,
+      more: !!(reposts && reposts.next_href),
       nonSetCount: countNonSets(repostTracks),
       artwork: bigArtwork(repostTracks[0] && repostTracks[0].artwork_url),
     });


### PR DESCRIPTION
Two layers of pagination for SoundCloud crates — same root cause as #74, one level down (tracks within a crate).

## 1. Data — fetch all tracks (was: first 50 only)
Opening a crate fetched `/soundcloud/playlists/:urn/tracks` once, and the backend caps each page at 50 — so you saw 50 of 207, and the other 157 were genuinely missing (search/sort/analyze never saw them).

- **`fetchScTracks(scFetch, path)`** (new export) follows the linked-partitioning `next_href` (via the backend's `/soundcloud/next`, reusing `fetchAllPages`) and normalizes the `{ track: {...} }` wrappers.
- `SoundCloudCrate` uses it, so **playlists, Liked Tracks, and Reposts load in full** when opened.

## 2. Display — paginate the table (was: render all rows at once)
Loading all 207 then rendering them in one table is a wall of rows. Now the table renders **only the current page** (default **100/page**, options 50/100/200), matching the Spotify track view — search/sort still run across the whole crate, and only the current page is in the DOM.

## Liked Tracks / Reposts tiles
Their grid tiles still fetch only the first page for the count (paging through thousands of likes on every library load would be heavy), so they show a **"50+"** floor when there's more; the full list loads on open. Playlist tiles are unaffected (count comes from SoundCloud's `track_count`).

## Verification
- `eslint` clean; `react-scripts build` compiles (only the pre-existing `Playlist.jsx` / `Recommendations.jsx` warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)