### PR TITLE
SoundCloud playback in the shared bottom player bar

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -118,6 +118,8 @@ const PLAYER_STYLES = {
   loaderColor: '#1ED760',
   sliderColor: '#1ED760',
 };
+// The SoundCloud bar sits on TOP of the (always-mounted) Spotify player.
+const SC_PLAYER_WRAP_STYLE = { ...PLAYER_WRAP_STYLE, zIndex: 10000 };
 
 // Memoized so the Spotify Web Playback player only re-renders (and never
 // reconnects) when its own props change — not on every unrelated App re-render
@@ -140,7 +142,7 @@ const BottomPlayer = React.memo(({ token, uris, play }) => (
 // track changes. Shown instead of the Spotify player while a SC track is active
 // (one source plays at a time).
 const ScBottomPlayer = React.memo(({ track, onClose }) => (
-  <div style={PLAYER_WRAP_STYLE}>
+  <div style={SC_PLAYER_WRAP_STYLE}>
     <div style={{ position: 'relative', backgroundColor: '#111', lineHeight: 0 }}>
       <iframe
         key={track.urn || track.id}
@@ -1336,21 +1338,22 @@ class App extends React.Component {
             onLoadSet={this.loadSet}
           />
 
-          {/* Bottom player bar — the SoundCloud Widget while a SC track is
-              active, otherwise the Spotify Web Playback player. */}
-          {this.state.scNowPlaying ? (
+          {/* The Spotify player stays mounted at all times — unmounting it
+              tears down its Web Playback device ("Device not found"). While a
+              SoundCloud track plays, the SC widget overlays it (higher z-index)
+              and Spotify is paused. */}
+          {loggedIn && (
+            <BottomPlayer
+              token={this.state.access_token}
+              uris={this.state.player.uris}
+              play={this.state.player.isPlaying}
+            />
+          )}
+          {this.state.scNowPlaying && (
             <ScBottomPlayer
               track={this.state.scNowPlaying}
               onClose={() => this.setState({ scNowPlaying: null })}
             />
-          ) : (
-            loggedIn && (
-              <BottomPlayer
-                token={this.state.access_token}
-                uris={this.state.player.uris}
-                play={this.state.player.isPlaying}
-              />
-            )
           )}
         </div>
       </ThemeProvider>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -41,6 +41,7 @@ import {
   Brightness4,
   Brightness7,
   Build,
+  Close,
   Cloud,
   ExitToApp,
   GraphicEq,
@@ -63,6 +64,7 @@ import SetBuilder from './components/PLLibrary/SetBuilder';
 import KeyCalculator from './utils/KeyCalculator';
 import SpotifyPlayer from 'react-spotify-web-playback';
 import SpotifyIcon from './components/SpotifyIcon';
+import { scWidgetSrc } from './utils/soundcloudCrates';
 import { makeAppTheme, THEME_STORAGE_KEY } from './theme';
 
 // Utils
@@ -133,6 +135,41 @@ const BottomPlayer = React.memo(({ token, uris, play }) => (
   </div>
 ));
 
+// SoundCloud playback reuses the same bottom player-bar slot: the sanctioned
+// SoundCloud Widget (iframe), keyed by track so it reloads + autoplays when the
+// track changes. Shown instead of the Spotify player while a SC track is active
+// (one source plays at a time).
+const ScBottomPlayer = React.memo(({ track, onClose }) => (
+  <div style={PLAYER_WRAP_STYLE}>
+    <div style={{ position: 'relative', backgroundColor: '#111', lineHeight: 0 }}>
+      <iframe
+        key={track.urn || track.id}
+        title="SoundCloud player"
+        width="100%"
+        height="120"
+        scrolling="no"
+        frameBorder="no"
+        allow="autoplay"
+        src={scWidgetSrc(track)}
+      />
+      <IconButton
+        size="small"
+        onClick={onClose}
+        title="Close SoundCloud player"
+        style={{
+          position: 'absolute',
+          top: 4,
+          right: 4,
+          color: '#fff',
+          backgroundColor: 'rgba(0,0,0,0.45)',
+        }}
+      >
+        <Close fontSize="small" />
+      </IconButton>
+    </div>
+  </div>
+));
+
 class App extends React.Component {
   constructor(props) {
     super(props);
@@ -178,6 +215,9 @@ class App extends React.Component {
         uris: [],
         isPlaying: false,
       },
+      // The SoundCloud track currently in the bottom player bar (null = the
+      // Spotify player owns the bar instead). One source plays at a time.
+      scNowPlaying: null,
       // SoundCloud connection (separate source; tokens managed like Spotify's).
       soundcloud: {
         connected: !!soundcloudParams.access_token,
@@ -206,6 +246,7 @@ class App extends React.Component {
     this.openLibrary = this.openLibrary.bind(this);
     this.openFavorites = this.openFavorites.bind(this);
     this.updatePlayer = this.updatePlayer.bind(this);
+    this.playSoundcloudTrack = this.playSoundcloudTrack.bind(this);
     this.refreshAccessToken = this.refreshAccessToken.bind(this);
     this.scheduleTokenRefresh = this.scheduleTokenRefresh.bind(this);
 
@@ -561,7 +602,19 @@ class App extends React.Component {
         uris: uris,
         isPlaying: isPlaying,
       },
+      // Playing a Spotify track hands the bottom bar back to the Spotify player.
+      scNowPlaying: null,
     });
+  }
+
+  // Play a SoundCloud track in the shared bottom bar (swaps out the Spotify
+  // player, which stops it — one source at a time). Also mark Spotify paused so
+  // closing the SC player returns to a paused Spotify bar, not an auto-resume.
+  playSoundcloudTrack(track) {
+    this.setState((s) => ({
+      scNowPlaying: track,
+      player: { ...s.player, isPlaying: false },
+    }));
   }
 
   handleCloseChangelog() {
@@ -981,6 +1034,7 @@ class App extends React.Component {
                   soundcloudBackend={soundcloudBackend}
                   onRefreshSoundcloud={this.refreshSoundcloudToken}
                   hideSets={this.state.disableScSets}
+                  onPlaySoundcloud={this.playSoundcloudTrack}
                 />
               </FadeIn>
             ) : (
@@ -1282,13 +1336,21 @@ class App extends React.Component {
             onLoadSet={this.loadSet}
           />
 
-          {/* Spotify Player - always visible at bottom */}
-          {loggedIn && (
-            <BottomPlayer
-              token={this.state.access_token}
-              uris={this.state.player.uris}
-              play={this.state.player.isPlaying}
+          {/* Bottom player bar — the SoundCloud Widget while a SC track is
+              active, otherwise the Spotify Web Playback player. */}
+          {this.state.scNowPlaying ? (
+            <ScBottomPlayer
+              track={this.state.scNowPlaying}
+              onClose={() => this.setState({ scNowPlaying: null })}
             />
+          ) : (
+            loggedIn && (
+              <BottomPlayer
+                token={this.state.access_token}
+                uris={this.state.player.uris}
+                play={this.state.player.isPlaying}
+              />
+            )
           )}
         </div>
       </ThemeProvider>

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -1807,6 +1807,7 @@ let PLLibrary = (props) => {
             onRefreshToken={props.onRefreshSoundcloud}
             onBack={() => setScOpened(null)}
             hideSets={props.hideSets}
+            onPlaySoundcloud={props.onPlaySoundcloud}
           />
         )}
       </Dialog>

--- a/client/src/components/SoundCloud/SoundCloudCrate.jsx
+++ b/client/src/components/SoundCloud/SoundCloudCrate.jsx
@@ -174,9 +174,12 @@ let SoundCloudCrate = (props) => {
   );
 
   // Play a track → load the Widget AND kick off analysis (non-blocking).
+  // Playback happens in the shared bottom player bar (lifted to App); we keep
+  // local `playing` only to highlight the active row. Analysis is independent.
   const playTrack = (t) => {
     setPlaying(t);
     enqueueAnalysis(t);
+    if (props.onPlaySoundcloud) props.onPlaySoundcloud(t);
   };
 
   // "Analyze Crate" → enqueue every track in the open crate.
@@ -210,28 +213,6 @@ let SoundCloudCrate = (props) => {
       cancelled = true;
     };
   }, [crate, scFetch]);
-
-  // SoundCloud's sanctioned HTML5 Widget (iframe) — ToS-compliant playback with
-  // no OAuth. Public tracks resolve from the permalink; PRIVATE tracks need
-  // their secret (secret_uri, or the permalink with a secret_token) or the
-  // widget 403s.
-  const widgetSrc = (track) => {
-    let url = track.permalink_url || track.uri;
-    if (track.sharing === "private") {
-      if (track.secret_uri) {
-        url = track.secret_uri;
-      } else if (track.secret_token) {
-        const base = track.permalink_url || track.uri;
-        url = base + (base.indexOf("?") >= 0 ? "&" : "?") +
-          "secret_token=" + track.secret_token;
-      }
-    }
-    return (
-      "https://w.soundcloud.com/player/?url=" +
-      encodeURIComponent(url) +
-      "&color=%23ff5500&auto_play=true&show_comments=false&visual=false"
-    );
-  };
 
   // Filtered + sorted track view (search + clickable column sort). Sorting by
   // key/BPM uses our analysis; un-analyzed tracks sort last.
@@ -322,20 +303,6 @@ let SoundCloudCrate = (props) => {
         )}
       </Box>
 
-      {playing && (
-        <Box style={{ marginBottom: 12 }}>
-          <iframe
-            title="SoundCloud player"
-            width="100%"
-            height="120"
-            scrolling="no"
-            frameBorder="no"
-            allow="autoplay"
-            src={widgetSrc(playing)}
-            style={{ borderRadius: 8 }}
-          />
-        </Box>
-      )}
 
       {tracks && tracks.length > 0 && (
         <Paper

--- a/client/src/utils/soundcloudCrates.js
+++ b/client/src/utils/soundcloudCrates.js
@@ -73,6 +73,30 @@ export async function fetchScTracks(scFetch, path) {
   return items.map((t) => (t && t.track ? t.track : t)).filter(Boolean);
 }
 
+// SoundCloud's sanctioned HTML5 Widget URL — ToS-compliant playback with no
+// OAuth. Public tracks resolve from the permalink; PRIVATE tracks need their
+// secret (secret_uri, or the permalink + secret_token) or the widget 403s.
+export function scWidgetSrc(track) {
+  let url = track.permalink_url || track.uri;
+  if (track.sharing === "private") {
+    if (track.secret_uri) {
+      url = track.secret_uri;
+    } else if (track.secret_token) {
+      const base = track.permalink_url || track.uri;
+      url =
+        base +
+        (base.indexOf("?") >= 0 ? "&" : "?") +
+        "secret_token=" +
+        track.secret_token;
+    }
+  }
+  return (
+    "https://w.soundcloud.com/player/?url=" +
+    encodeURIComponent(url) +
+    "&color=%23ff5500&auto_play=true&show_comments=false&visual=false"
+  );
+}
+
 // Fetch the user's SoundCloud crates: Liked Tracks + Reposts as virtual crates
 // (artwork from the first track) plus their playlists/sets. Returns a plain
 // array of crate descriptors:


### PR DESCRIPTION
## What

SoundCloud playback now lives in the **bottom player-bar area** (where the Spotify player sits), instead of an inline widget at the top of the open crate. So SoundCloud feels like a real player — and it **keeps playing after you close the crate**.

## How it works

- `App` owns a `scNowPlaying` track. The **Spotify Web Playback player stays mounted at all times** (unmounting it tears down its device → "Device not found"). While a SoundCloud track is active, the **SoundCloud Widget** (`ScBottomPlayer`) overlays it (higher z-index) and Spotify is paused.
- **One source at a time:**
  - Playing a SoundCloud track shows the SC widget on top and pauses Spotify.
  - Playing a Spotify track (`updatePlayer`) dismisses the SC widget and resumes the Spotify player (same persistent device).
  - A **✕** on the SC bar returns to the paused Spotify player.
- `SoundCloudCrate.playTrack` calls up via `onPlaySoundcloud` (`App → PLLibrary → SoundCloudCrate`) instead of rendering its own iframe. It keeps a local `playing` only to highlight the active row; analysis-on-play is unchanged.
- Extracted `scWidgetSrc` into `utils/soundcloudCrates.js` (shared by the bar; removed from `SoundCloudCrate`).

This is the per-source-playback piece from the unification plan (Spotify → Web Playback, SoundCloud → Widget), and it sets up Phase 2's combined browser.

## Notes

- The SC widget is the sanctioned SoundCloud Widget iframe (ToS-compliant, no custom streaming). It autoplays and reloads when the track changes (keyed by track).
- The full-screen crate modal has bottom padding, so the bar doesn't cover its last rows.

## Verification

- `eslint` clean; `react-scripts build` compiles (only pre-existing `Playlist.jsx` / `Recommendations.jsx` warnings)
- Live check: play a SC track → SC bar appears + Spotify pauses; close the crate → keeps playing; play a Spotify track → Spotify resumes (no "Device not found"); ✕ on the SC bar → Spotify player returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)