### PR TITLE
Heroku container deploy config for the analysis service

### DIFF
--- a/analysis-service/Dockerfile
+++ b/analysis-service/Dockerfile
@@ -32,6 +32,7 @@ COPY package*.json ./
 RUN npm install --omit=dev
 COPY . .
 
-ENV PORT=8899
+# No hardcoded PORT — the host (Heroku/Fly/Render) injects $PORT at runtime and
+# server.js binds to it (falling back to 8899 for local `docker run`).
 EXPOSE 8899
 CMD ["node", "server.js"]

--- a/analysis-service/heroku.yml
+++ b/analysis-service/heroku.yml
@@ -1,0 +1,9 @@
+# Heroku container deploy for the analysis microservice.
+# The app uses the `container` stack and builds this directory's Dockerfile
+# remotely (no local Docker needed). Deploy by pushing just this subdir as the
+# app root, e.g.:
+#   git subtree push --prefix analysis-service heroku-analysis main
+# Heroku injects $PORT at runtime; server.js binds to it.
+build:
+  docker:
+    web: Dockerfile


### PR DESCRIPTION
Adds the config to deploy the key/BPM analysis microservice to Heroku as a **container** app (so it ships with ffmpeg + keyfinder-cli + bpm-tools, which don't install on a normal buildpack).

- **`analysis-service/heroku.yml`** — builds the service's `Dockerfile` on Heroku's `container` stack, remotely (no local Docker needed). Deployed by subtree-pushing just `analysis-service/` as the app root.
- **`Dockerfile`** — drop the hardcoded `ENV PORT=8899` so Heroku's injected `$PORT` is used (`server.js` already binds to `process.env.PORT`, falling back to 8899 for local `docker run`).

Deploy steps (run separately): create the `keytrack-analysis` app on the `container` stack, `git subtree push` this dir, then set `ANALYSIS_SERVICE_URL` on the `key-track2` backend to the new app's URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)