### PR TITLE
Protect analysis /analyze with a shared secret

### DIFF
--- a/analysis-service/server.js
+++ b/analysis-service/server.js
@@ -10,9 +10,17 @@ const { analyzeUrl } = require("./analyze");
 const app = express();
 app.use(express.json({ limit: "256kb" }));
 
+// Shared secret: when ANALYSIS_SECRET is set (prod), /analyze requires a
+// matching x-analysis-secret header so only our backend can call it. Left open
+// when unset (local dev). /health stays open for uptime checks.
+const ANALYSIS_SECRET = process.env.ANALYSIS_SECRET || "";
+
 app.get("/health", (_req, res) => res.send({ ok: true }));
 
 app.post("/analyze", async (req, res) => {
+  if (ANALYSIS_SECRET && req.headers["x-analysis-secret"] !== ANALYSIS_SECRET) {
+    return res.status(401).send({ error: "unauthorized" });
+  }
   const { audioUrl, authHeader, durationMs, genre } = req.body || {};
   if (!audioUrl) return res.status(400).send({ error: "audioUrl required" });
   try {

--- a/local-server/index.js
+++ b/local-server/index.js
@@ -473,6 +473,8 @@ app.get(
 // ---------------------------------------------------------------------------
 const ANALYSIS_SERVICE_URL =
   process.env.ANALYSIS_SERVICE_URL || 'http://127.0.0.1:8899';
+// Shared secret so only this backend can call the (public) analysis service.
+const ANALYSIS_SECRET = process.env.ANALYSIS_SECRET || '';
 const LIKELY_SET_MS = 6 * 60 * 1000;
 
 app.get(
@@ -504,6 +506,7 @@ app.get(
         request.post(
           {
             url: ANALYSIS_SERVICE_URL + '/analyze',
+            headers: { 'x-analysis-secret': ANALYSIS_SECRET },
             json: {
               audioUrl,
               authHeader: 'OAuth ' + token,


### PR DESCRIPTION
Locks down the now-public analysis microservice so only the KeyTrack backend can call `/analyze` (it's an open endpoint that fetches arbitrary URLs + runs ffmpeg — abuse / dyno-hour-burn risk otherwise).

- **analysis-service** (`server.js`): when `ANALYSIS_SECRET` is set, `/analyze` requires a matching `x-analysis-secret` header (401 otherwise). Open when unset (local dev). `/health` stays open for uptime checks.
- **backend** (`local-server/index.js`): sends the `x-analysis-secret` header (from `ANALYSIS_SECRET`) on the call to the analysis service.

The secret is **already provisioned** as a Heroku config var (identical value) on both `keytrack-analysis` and `key-track2`.

## Deploy (needs both apps, in order — backend first)
1. `key-track2` (backend) — so it starts sending the header **before** the service requires it. ⚠️ production push, needs your OK.
2. `keytrack-analysis` (service) — `git subtree push --prefix analysis-service heroku-analysis main`.

Until both are deployed, prod is unchanged and working (old code ignores the secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)