### PR TITLE
Phase 2a: unified track model + reusable SoundCloud analysis hook

### DIFF
--- a/client/src/components/SoundCloud/SoundCloudCrate.jsx
+++ b/client/src/components/SoundCloud/SoundCloudCrate.jsx
@@ -31,8 +31,8 @@ import {
 } from "@material-ui/icons";
 
 import { camelotColor } from "../../utils/harmonic";
-import { getScAnalysis, saveScAnalysis } from "../../utils/scAnalysis";
 import { fetchScTracks } from "../../utils/soundcloudCrates";
+import { useScAnalysisQueue } from "./useScAnalysisQueue";
 
 // SoundCloud's brand orange — keeps SoundCloud crates visually distinct from
 // Spotify's green (strict source separation).
@@ -80,13 +80,8 @@ const ScSortLabel = withStyles({
 let SoundCloudCrate = (props) => {
   const { crate, onBack } = props;
   const [tracks, setTracks] = React.useState(null);
-  // The track currently loaded into the embedded SoundCloud Widget player.
+  // The track currently highlighted as playing (playback is in the bottom bar).
   const [playing, setPlaying] = React.useState(null);
-  // Our computed key/BPM per track URN: { status:'loading' } | result.
-  const [analysis, setAnalysis] = React.useState({});
-  const queueRef = React.useRef([]); // FIFO of tracks awaiting analysis
-  const seenRef = React.useRef(new Set()); // urns already queued/done (dedupe)
-  const processingRef = React.useRef(false);
   // Within-crate search + column sort (parity with the Spotify track table).
   const [search, setSearch] = React.useState("");
   const [sort, setSort] = React.useState({ col: null, dir: "asc" });
@@ -119,71 +114,20 @@ let SoundCloudCrate = (props) => {
     [props]
   );
 
-  // --- Key/BPM analysis: a single-worker FIFO queue. Enqueuing never blocks
-  // (playback is independent); results fill in live and cache to Firestore so a
-  // track is only ever analyzed once for the whole app.
-  const trackUrn = (t) => t.urn || String(t.id);
+  // Lazy key/BPM analysis (SoundCloud has none) via the shared single-worker
+  // queue. Results fill in live and cache app-wide.
+  const { analysis, enqueue, enqueueAll } = useScAnalysisQueue(scFetch);
 
-  const processQueue = React.useCallback(() => {
-    if (processingRef.current) return;
-    processingRef.current = true;
-    (async () => {
-      while (queueRef.current.length) {
-        const t = queueRef.current.shift();
-        const urn = trackUrn(t);
-        let result = await getScAnalysis(urn); // shared cache first
-        if (!result) {
-          try {
-            const tid = t.id || t.urn;
-            result = await scFetch(
-              `/soundcloud/analyze?track_id=${encodeURIComponent(tid)}` +
-                `&duration=${t.duration || 0}` +
-                `&genre=${encodeURIComponent(t.genre || "")}`
-            );
-            if (result && !result.isLikelySet && result.camelot) {
-              saveScAnalysis(urn, result);
-            }
-          } catch (e) {
-            result = { error: true };
-          }
-        }
-        setAnalysis((a) => ({ ...a, [urn]: result || { error: true } }));
-        // Failed (e.g. HLS-only / no progressive stream) → allow a retry later.
-        if (!result || result.error || (!result.camelot && !result.isLikelySet)) {
-          seenRef.current.delete(urn);
-        }
-      }
-      processingRef.current = false;
-    })();
-  }, [scFetch]);
-
-  const enqueueAnalysis = React.useCallback(
-    (t) => {
-      const urn = trackUrn(t);
-      if (seenRef.current.has(urn)) return; // already queued/done
-      seenRef.current.add(urn);
-      if (isLikelySet(t.duration)) {
-        setAnalysis((a) => ({ ...a, [urn]: { isLikelySet: true } }));
-        return;
-      }
-      setAnalysis((a) => ({ ...a, [urn]: { status: "loading" } }));
-      queueRef.current.push(t);
-      processQueue();
-    },
-    [processQueue]
-  );
-
-  // Play a track → load the Widget AND kick off analysis (non-blocking).
-  // Playback happens in the shared bottom player bar (lifted to App); we keep
-  // local `playing` only to highlight the active row. Analysis is independent.
+  // Play a track → bottom-bar playback (lifted to App) + kick off analysis
+  // (non-blocking). Local `playing` only highlights the active row.
   const playTrack = (t) => {
     setPlaying(t);
-    enqueueAnalysis(t);
+    enqueue(t);
     if (props.onPlaySoundcloud) props.onPlaySoundcloud(t);
   };
 
   // "Analyze Crate" → enqueue every track in the open crate.
-  const analyzeCrate = () => (tracks || []).forEach((t) => enqueueAnalysis(t));
+  const analyzeCrate = () => enqueueAll(tracks);
 
   // Load the crate's tracks. Likes/reposts have their own endpoints; a
   // playlist's tracks come from /playlists/:urn/tracks.

--- a/client/src/components/SoundCloud/useScAnalysisQueue.js
+++ b/client/src/components/SoundCloud/useScAnalysisQueue.js
@@ -1,0 +1,78 @@
+import React from "react";
+import { getScAnalysis, saveScAnalysis } from "../../utils/scAnalysis";
+import { isLikelySet } from "../../utils/soundcloudCrates";
+
+// A single-worker FIFO queue that lazily computes our key/BPM for SoundCloud
+// tracks (SoundCloud has none). Enqueuing never blocks playback; results fill
+// in live and cache to Firestore so a track is only ever analyzed once for the
+// whole app. Shared by the standalone SoundCloud crate view and the combined
+// multi-source browser.
+//
+// Returns:
+//   analysis  { [urn]: {status:'loading'} | {isLikelySet} | {camelot,key,bpm} | {error} }
+//   enqueue(track)      queue one track for analysis
+//   enqueueAll(tracks)  queue many (e.g. "Analyze crate")
+export function useScAnalysisQueue(scFetch) {
+  const [analysis, setAnalysis] = React.useState({});
+  const queueRef = React.useRef([]); // FIFO of tracks awaiting analysis
+  const seenRef = React.useRef(new Set()); // urns already queued/done (dedupe)
+  const processingRef = React.useRef(false);
+
+  const trackUrn = (t) => t.urn || String(t.id);
+
+  const processQueue = React.useCallback(() => {
+    if (processingRef.current) return;
+    processingRef.current = true;
+    (async () => {
+      while (queueRef.current.length) {
+        const t = queueRef.current.shift();
+        const urn = trackUrn(t);
+        let result = await getScAnalysis(urn); // shared cache first
+        if (!result) {
+          try {
+            const tid = t.id || t.urn;
+            result = await scFetch(
+              `/soundcloud/analyze?track_id=${encodeURIComponent(tid)}` +
+                `&duration=${t.duration || 0}` +
+                `&genre=${encodeURIComponent(t.genre || "")}`
+            );
+            if (result && !result.isLikelySet && result.camelot) {
+              saveScAnalysis(urn, result);
+            }
+          } catch (e) {
+            result = { error: true };
+          }
+        }
+        setAnalysis((a) => ({ ...a, [urn]: result || { error: true } }));
+        // Failed (e.g. HLS-only / no progressive stream) → allow a retry later.
+        if (!result || result.error || (!result.camelot && !result.isLikelySet)) {
+          seenRef.current.delete(urn);
+        }
+      }
+      processingRef.current = false;
+    })();
+  }, [scFetch]);
+
+  const enqueue = React.useCallback(
+    (t) => {
+      const urn = trackUrn(t);
+      if (seenRef.current.has(urn)) return; // already queued/done
+      seenRef.current.add(urn);
+      if (isLikelySet(t.duration)) {
+        setAnalysis((a) => ({ ...a, [urn]: { isLikelySet: true } }));
+        return;
+      }
+      setAnalysis((a) => ({ ...a, [urn]: { status: "loading" } }));
+      queueRef.current.push(t);
+      processQueue();
+    },
+    [processQueue]
+  );
+
+  const enqueueAll = React.useCallback(
+    (tracks) => (tracks || []).forEach(enqueue),
+    [enqueue]
+  );
+
+  return { analysis, enqueue, enqueueAll };
+}

--- a/client/src/utils/unifiedTrack.js
+++ b/client/src/utils/unifiedTrack.js
@@ -1,0 +1,80 @@
+import KeyMap from "./KeyMap";
+import { formatReleaseDate } from "./release";
+
+// A track normalized to one source-agnostic shape so the combined browser can
+// render Spotify and SoundCloud tracks in a single table. Only the harmonic
+// language (Camelot/BPM) is unified — source-specific fields (energy/released
+// for Spotify, genre for SoundCloud) stay populated for one source and null for
+// the other, which the superset columns render as blanks.
+//
+//   uid          unique React key across sources ('sp:<id>' / 'sc:<urn>')
+//   source       'spotify' | 'soundcloud'
+//   camelot      Camelot code (both sources) | null if unknown/not-yet-analyzed
+//   energy       0..1 (Spotify) | null
+//   genre        string (SoundCloud) | null
+//   released     formatted date string (Spotify) | null
+//   spotifyUri   for Web Playback (Spotify) | null
+//   externalUrl  permalink to open on the source
+//   raw          the original item/track (for playback + per-source actions)
+
+// Spotify playlist item + its audio-features ({ key, mode, bpm, energy } from
+// Playlist's getKey, or null) -> unified.
+export function spotifyToUnified(item, feat) {
+  const t = item.track;
+  const km = feat && feat.key != null ? KeyMap[feat.key] : null;
+  return {
+    uid: "sp:" + t.id,
+    source: "spotify",
+    title: t.name,
+    artist: (t.artists || []).map((a) => a.name).join(", "),
+    artwork: t.album && t.album.images[0] ? t.album.images[0].url : null,
+    camelot: km ? km.camelot[feat.mode] : null,
+    keyName: km ? km.key : null,
+    mode: feat ? feat.mode : null,
+    bpm: feat && feat.bpm != null ? Math.round(feat.bpm) : null,
+    energy: feat && feat.energy != null ? feat.energy : null,
+    genre: null,
+    released: formatReleaseDate(t),
+    durationMs: t.duration_ms || null,
+    externalUrl: t.external_urls ? t.external_urls.spotify : null,
+    spotifyUri: t.uri,
+    raw: item,
+  };
+}
+
+// SoundCloud track + our analysis ({ camelot, key, bpm } or null) -> unified.
+// Analysis is lazy, so callers re-derive (or overlay) as results arrive.
+export function soundcloudToUnified(track, analysis) {
+  const a = analysis && analysis.camelot ? analysis : null;
+  return {
+    uid: "sc:" + (track.urn || track.id),
+    source: "soundcloud",
+    title: track.title,
+    artist: track.user && track.user.username ? track.user.username : "",
+    artwork: track.artwork_url || null,
+    camelot: a ? a.camelot : null,
+    keyName: a ? a.key : null,
+    mode: null,
+    bpm: a && a.bpm != null ? a.bpm : null,
+    energy: null,
+    genre: track.genre || null,
+    released: null,
+    durationMs: track.duration || null,
+    externalUrl: track.permalink_url || null,
+    spotifyUri: null,
+    raw: track,
+  };
+}
+
+// Sort rank for a Camelot code ("8B" -> 17) so a key column sorts around the
+// wheel; unknown keys sort last. Shared by the combined browser.
+export function camelotRank(c) {
+  const m = /(\d+)([AB])/.exec(c || "");
+  return m ? parseInt(m[1], 10) * 2 + (m[2] === "B" ? 1 : 0) : 9999;
+}
+
+export function fmtDuration(ms) {
+  if (!ms) return "—";
+  const s = Math.round(ms / 1000);
+  return Math.floor(s / 60) + ":" + String(s % 60).padStart(2, "0");
+}


### PR DESCRIPTION
**Phase 2 (combined multi-source track browser) — foundation.** No user-facing behavior change; this is the plumbing the combined browser builds on.

- **`utils/unifiedTrack.js`** — `spotifyToUnified(item, features)` and `soundcloudToUnified(track, analysis)` normalize both sources into one shape. Only the harmonic language (Camelot/BPM) is unified; source-only fields stay populated for one source and `null` for the other (Energy/Released → Spotify, Genre → SoundCloud), which the superset columns will render as blanks. Plus `camelotRank` + `fmtDuration` helpers.
- **`components/SoundCloud/useScAnalysisQueue.js`** — extracts `SoundCloudCrate`'s single-worker lazy key/BPM analyze queue into a reusable hook (same Firestore caching, dedupe, retry-on-failure) so the combined browser can run SoundCloud analysis the same way.
- **`SoundCloudCrate`** now consumes the hook (`analysis` / `enqueue` / `enqueueAll`) instead of its inline queue — identical behavior, verified by build.

## Next
- **2b** — `CombinedCrate`: the combined table (source badge per row, superset columns, Camelot sort/filter + harmonic anchor, per-source playback, SoundCloud external links + lazy analysis).
- **2c** — wire Open(N): a SoundCloud-inclusive selection opens the combined browser; pure-Spotify keeps the rich Playlist.

## Verification
- `eslint` clean on all three files; `react-scripts build` compiles (only the pre-existing `Playlist.jsx` / `Recommendations.jsx` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)