### PR TITLE
Phase 2b: combined multi-source track browser

### DIFF
--- a/client/src/components/PLLibrary/CombinedCrate.jsx
+++ b/client/src/components/PLLibrary/CombinedCrate.jsx
@@ -1,0 +1,381 @@
+import React from "react";
+import {
+  Dialog,
+  Box,
+  Typography,
+  IconButton,
+  Avatar,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableSortLabel,
+  TablePagination,
+  Input,
+  InputAdornment,
+  Paper,
+  CircularProgress,
+} from "@material-ui/core";
+import { ArrowBack, Search, OpenInNew } from "@material-ui/icons";
+
+import { camelotColor } from "../../utils/harmonic";
+import { camelotRank, fmtDuration } from "../../utils/unifiedTrack";
+import { SpotifyIcon, SoundcloudIcon } from "../BrandIcons";
+import { useScAnalysisQueue } from "../SoundCloud/useScAnalysisQueue";
+
+const SC_ORANGE = "#ff5500";
+const SPOTIFY_GREEN = "#1ED760";
+
+// The combined multi-source track browser: Spotify + SoundCloud tracks in one
+// table. Spotify rows come fully populated (key/BPM/energy/released from audio
+// features); SoundCloud rows get our key/BPM lazily (auto-analyzed on open) and
+// keep an "open on SoundCloud" link. Superset columns blank out where a source
+// has no data (Energy/Released for SC, Genre for Spotify). Per-source playback:
+// Spotify → Web Playback bar, SoundCloud → the Widget bar.
+//
+// Props: open, onClose, title, tracks (unified[]), scFetch, updatePlayer,
+// onPlaySoundcloud.
+let CombinedCrate = (props) => {
+  const { tracks, open, onClose, title } = props;
+  const [search, setSearch] = React.useState("");
+  const [sort, setSort] = React.useState({ col: null, dir: "asc" });
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(100);
+  const [playingUid, setPlayingUid] = React.useState(null);
+
+  const { analysis, enqueueAll } = useScAnalysisQueue(props.scFetch);
+
+  // Auto-analyze the SoundCloud tracks on open so their key/BPM fill in (so you
+  // can sort/mix the whole combined crate harmonically). Single-worker queue.
+  React.useEffect(() => {
+    if (!open || !tracks) return;
+    const scRaw = tracks
+      .filter((t) => t.source === "soundcloud")
+      .map((t) => t.raw);
+    if (scRaw.length) enqueueAll(scRaw);
+  }, [open, tracks, enqueueAll]);
+
+  // Overlay live SoundCloud analysis onto the unified rows.
+  const merged = React.useMemo(() => {
+    return (tracks || []).map((t) => {
+      if (t.source !== "soundcloud") return t;
+      const urn = t.raw.urn || String(t.raw.id);
+      const a = analysis[urn];
+      if (a && a.camelot)
+        return { ...t, camelot: a.camelot, keyName: a.key, bpm: a.bpm, scStatus: "done" };
+      if (a && a.isLikelySet) return { ...t, scStatus: "set" };
+      if (a && a.status === "loading") return { ...t, scStatus: "loading" };
+      if (a && a.error) return { ...t, scStatus: "error" };
+      return { ...t, scStatus: "pending" };
+    });
+  }, [tracks, analysis]);
+
+  const view = React.useMemo(() => {
+    let list = merged;
+    const q = search.trim().toLowerCase();
+    if (q) {
+      list = list.filter(
+        (t) =>
+          (t.title || "").toLowerCase().includes(q) ||
+          (t.artist || "").toLowerCase().includes(q)
+      );
+    }
+    if (sort.col) {
+      const d = sort.dir === "desc" ? -1 : 1;
+      list = [...list].sort((a, b) => {
+        switch (sort.col) {
+          case "source":
+            return d * a.source.localeCompare(b.source);
+          case "title":
+            return d * (a.title || "").localeCompare(b.title || "");
+          case "artist":
+            return d * (a.artist || "").localeCompare(b.artist || "");
+          case "key":
+            return d * (camelotRank(a.camelot) - camelotRank(b.camelot));
+          case "bpm":
+            return d * ((a.bpm || 1e9) - (b.bpm || 1e9));
+          case "energy":
+            return d * ((a.energy == null ? -1 : a.energy) - (b.energy == null ? -1 : b.energy));
+          case "length":
+            return d * ((a.durationMs || 0) - (b.durationMs || 0));
+          default:
+            return 0;
+        }
+      });
+    }
+    return list;
+  }, [merged, search, sort]);
+
+  React.useEffect(() => {
+    setPage(0);
+  }, [search, sort, tracks]);
+  const paged = view.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
+  const toggleSort = (col) =>
+    setSort((s) =>
+      s.col === col
+        ? { col, dir: s.dir === "asc" ? "desc" : "asc" }
+        : { col, dir: "asc" }
+    );
+
+  const playRow = (t) => {
+    setPlayingUid(t.uid);
+    if (t.source === "spotify" && props.updatePlayer) {
+      props.updatePlayer([t.spotifyUri], true);
+    } else if (t.source === "soundcloud" && props.onPlaySoundcloud) {
+      props.onPlaySoundcloud(t.raw);
+    }
+  };
+
+  // Small per-row source badge.
+  const sourceBadge = (source) => {
+    const sc = source === "soundcloud";
+    return (
+      <span
+        title={sc ? "SoundCloud" : "Spotify"}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 4,
+          backgroundColor: sc ? SC_ORANGE : SPOTIFY_GREEN,
+          color: "#fff",
+          fontSize: 10,
+          fontWeight: 700,
+          padding: "2px 7px",
+          borderRadius: 10,
+        }}
+      >
+        {sc ? <SoundcloudIcon size={12} color="#fff" /> : <SpotifyIcon size={11} color="#fff" />}
+      </span>
+    );
+  };
+
+  // The Key cell — colored Camelot pill, or a per-source placeholder.
+  const keyCell = (t) => {
+    if (t.camelot) {
+      const c = camelotColor(t.camelot);
+      return (
+        <span
+          style={{
+            backgroundColor: c.bg,
+            color: c.text,
+            padding: "3px 8px",
+            borderRadius: 10,
+            fontWeight: 600,
+            fontSize: "0.8rem",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {t.camelot}
+          {t.keyName ? " · " + t.keyName : ""}
+        </span>
+      );
+    }
+    if (t.scStatus === "loading") {
+      return (
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 6, color: "#888" }}>
+          <CircularProgress size={12} style={{ color: SC_ORANGE }} />
+          analyzing…
+        </span>
+      );
+    }
+    if (t.scStatus === "set") {
+      return (
+        <span
+          style={{
+            backgroundColor: SC_ORANGE,
+            color: "#fff",
+            padding: "2px 7px",
+            borderRadius: 10,
+            fontSize: "0.72rem",
+            fontWeight: 700,
+          }}
+        >
+          Set
+        </span>
+      );
+    }
+    return "—";
+  };
+
+  const energyCell = (t) => {
+    if (t.energy == null) return "—";
+    const pct = Math.round(t.energy * 100);
+    return (
+      <div
+        title={`Energy ${pct}%`}
+        style={{ width: 46, height: 6, background: "rgba(128,128,128,0.2)", borderRadius: 3 }}
+      >
+        <div
+          style={{
+            width: `${pct}%`,
+            height: 6,
+            borderRadius: 3,
+            background: `hsl(${(1 - t.energy) * 200}, 75%, 48%)`,
+          }}
+        />
+      </div>
+    );
+  };
+
+  const headCell = (col, label, align) => (
+    <TableCell sortDirection={sort.col === col ? sort.dir : false} align={align}>
+      <TableSortLabel
+        active={sort.col === col}
+        direction={sort.col === col ? sort.dir : "asc"}
+        onClick={() => toggleSort(col)}
+      >
+        {label}
+      </TableSortLabel>
+    </TableCell>
+  );
+
+  const scCount = (tracks || []).filter((t) => t.source === "soundcloud").length;
+  const analyzing =
+    scCount > 0 &&
+    merged.filter((t) => t.source === "soundcloud" && t.scStatus === "loading").length > 0;
+
+  return (
+    <Dialog fullScreen open={open} onClose={onClose}>
+      {/* paddingBottom clears the fixed bottom player bar. */}
+      <Box style={{ padding: 16, paddingBottom: 140 }}>
+        <Box style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+          <IconButton size="small" onClick={onClose} title="Back to crates">
+            <ArrowBack />
+          </IconButton>
+          <Typography variant="h6" style={{ fontWeight: 700 }} noWrap>
+            {title}
+          </Typography>
+          {analyzing && (
+            <Typography
+              variant="caption"
+              color="textSecondary"
+              style={{ display: "inline-flex", alignItems: "center", gap: 5 }}
+            >
+              <CircularProgress size={12} style={{ color: SC_ORANGE }} />
+              analyzing SoundCloud keys…
+            </Typography>
+          )}
+        </Box>
+        <Typography variant="caption" color="textSecondary" style={{ display: "block", marginBottom: 12, paddingLeft: 4 }}>
+          Combined crate · {(tracks || []).length} tracks. Spotify keys are from
+          audio features; SoundCloud keys are computed by KeyTrack.
+        </Typography>
+
+        {(tracks || []).length > 0 && (
+          <Paper
+            elevation={0}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              maxWidth: 360,
+              borderRadius: 24,
+              padding: "2px 8px 2px 16px",
+              marginBottom: 12,
+              border: "1px solid rgba(128,128,128,0.28)",
+            }}
+          >
+            <Input
+              disableUnderline
+              fullWidth
+              type="text"
+              placeholder="Search these tracks"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              endAdornment={
+                <InputAdornment position="end">
+                  <Search style={{ color: "rgba(128,128,128,0.8)" }} />
+                </InputAdornment>
+              }
+            />
+          </Paper>
+        )}
+
+        <Box style={{ overflowX: "auto" }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell></TableCell>
+                {headCell("source", "Src")}
+                {headCell("title", "Track")}
+                {headCell("artist", "Artist")}
+                {headCell("key", "Key")}
+                {headCell("bpm", "BPM")}
+                {headCell("energy", "Energy")}
+                <TableCell>Genre</TableCell>
+                <TableCell>Released</TableCell>
+                {headCell("length", "Length")}
+                <TableCell></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {paged.map((t) => {
+                const isPlaying = playingUid === t.uid;
+                return (
+                  <TableRow
+                    key={t.uid}
+                    hover
+                    style={{
+                      cursor: "pointer",
+                      backgroundColor: isPlaying
+                        ? t.source === "soundcloud"
+                          ? "rgba(255,85,0,0.08)"
+                          : "rgba(30,215,96,0.10)"
+                        : undefined,
+                    }}
+                    onClick={() => playRow(t)}
+                  >
+                    <TableCell style={{ width: 44 }}>
+                      <Avatar variant="rounded" src={t.artwork} style={{ width: 34, height: 34 }} />
+                    </TableCell>
+                    <TableCell>{sourceBadge(t.source)}</TableCell>
+                    <TableCell style={{ fontWeight: 600, maxWidth: 280 }}>{t.title}</TableCell>
+                    <TableCell style={{ maxWidth: 200 }}>{t.artist}</TableCell>
+                    <TableCell>{keyCell(t)}</TableCell>
+                    <TableCell>{t.bpm || "—"}</TableCell>
+                    <TableCell>{energyCell(t)}</TableCell>
+                    <TableCell>{t.genre || "—"}</TableCell>
+                    <TableCell style={{ whiteSpace: "nowrap" }}>{t.released || "—"}</TableCell>
+                    <TableCell style={{ whiteSpace: "nowrap" }}>{fmtDuration(t.durationMs)}</TableCell>
+                    <TableCell>
+                      {t.source === "soundcloud" && t.externalUrl && (
+                        <IconButton
+                          size="small"
+                          href={t.externalUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title="Open on SoundCloud"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <OpenInNew fontSize="small" />
+                        </IconButton>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </Box>
+
+        {view.length > 50 && (
+          <TablePagination
+            component="div"
+            count={view.length}
+            page={page}
+            onChangePage={(e, p) => setPage(p)}
+            rowsPerPage={rowsPerPage}
+            onChangeRowsPerPage={(e) => {
+              setRowsPerPage(parseInt(e.target.value, 10));
+              setPage(0);
+            }}
+            rowsPerPageOptions={[50, 100, 200]}
+            labelRowsPerPage="Tracks per page"
+          />
+        )}
+      </Box>
+    </Dialog>
+  );
+};
+
+export default CombinedCrate;

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -59,7 +59,9 @@ import Spotify from "spotify-web-api-js";
 
 import Playlist from "./Playlist";
 import SoundCloudCrate from "../SoundCloud/SoundCloudCrate";
+import CombinedCrate from "./CombinedCrate";
 import { SpotifyIcon, SoundcloudIcon } from "../BrandIcons";
+import { spotifyToUnified, soundcloudToUnified } from "../../utils/unifiedTrack";
 import { useEffect } from "react";
 import { fetchCrateMeta, setCrateMeta } from "../../utils/crateMeta";
 import {
@@ -72,6 +74,7 @@ import {
   buildScFetch,
   fetchSoundcloudCrates,
   fetchScSetCounts,
+  fetchScTracks,
 } from "../../utils/soundcloudCrates";
 
 // SoundCloud brand orange (source badge + toggle), distinct from Spotify green.
@@ -355,6 +358,9 @@ let PLLibrary = (props) => {
   const setCountTriedRef = React.useRef(new Set());
   // The SoundCloud crate opened in the full-screen modal (null = closed).
   const [scOpened, setScOpened] = React.useState(null);
+  // Combined multi-source browser, opened from a SoundCloud-inclusive Open(N).
+  const [combinedTracks, setCombinedTracks] = React.useState(null);
+  const [combinedTitle, setCombinedTitle] = React.useState("");
 
   // Library source toggles (Spotify / SoundCloud). At least one must stay on;
   // both default on; persisted. The SoundCloud toggle only matters once a
@@ -794,63 +800,103 @@ let PLLibrary = (props) => {
   };
 
   const handleOpenSelected = async () => {
-    // Open the selected crates as one combined view ("Select all" selects them
-    // all). Hidden crates never feed this even if somehow selected.
-    // Cross-search is Spotify-only (it relies on Spotify audio-features);
-    // SoundCloud crates open individually. Hidden crates never feed this.
-    const playlists = library.filter(
-      (c) =>
-        c.source === "spotify" &&
-        selected.has(c.uid) &&
-        !(crateMeta[c.uid] && crateMeta[c.uid].hidden)
+    // Selected, non-hidden crates across both sources.
+    const chosen = library.filter(
+      (c) => selected.has(c.uid) && !(crateMeta[c.uid] && crateMeta[c.uid].hidden)
     );
-    if (playlists.length === 0) return;
+    if (chosen.length === 0) return;
+    const spotifyCrates = chosen.filter((c) => c.source === "spotify");
+    const scCratesSel = chosen.filter((c) => c.source === "soundcloud");
 
     cancelAllRef.current = false;
-    setAllProgress({ done: 0, total: playlists.length });
+    setAllProgress({ done: 0, total: chosen.length });
     setLoadingAll(true);
     try {
-      const perPlaylist = await mapWithLimit(playlists, 4, async (c) => {
-        // Skip queued/in-flight work once the user has cancelled.
-        if (cancelAllRef.current) return { tracks: [], features: [] };
-        const tracks = await fetchAllTracks(c.uid);
-        if (cancelAllRef.current) return { tracks: [], features: [] };
-        const features = await fetchFeatures(tracks.map((t) => t.track.id));
+      // Pure-Spotify selection → the rich Playlist view (audio features +
+      // recommendations + set builder). Unchanged behavior.
+      if (scCratesSel.length === 0) {
+        const perPlaylist = await mapWithLimit(spotifyCrates, 4, async (c) => {
+          if (cancelAllRef.current) return { tracks: [], features: [] };
+          const tracks = await fetchAllTracks(c.uid);
+          if (cancelAllRef.current) return { tracks: [], features: [] };
+          const features = await fetchFeatures(tracks.map((t) => t.track.id));
+          setAllProgress((p) => ({ ...p, done: p.done + 1 }));
+          return { tracks, features };
+        });
+        if (cancelAllRef.current) return;
+        const seen = new Set();
+        const allTracks = [];
+        const featById = new Map();
+        perPlaylist.forEach(({ tracks, features }) => {
+          tracks.forEach((item) => {
+            if (!seen.has(item.track.id)) {
+              seen.add(item.track.id);
+              allTracks.push(item);
+            }
+          });
+          features.forEach((f) => {
+            if (f) featById.set(f.id, f);
+          });
+        });
+        setPlaylistName(
+          `${spotifyCrates.length} crate${spotifyCrates.length === 1 ? "" : "s"} · ${allTracks.length} tracks`
+        );
+        setPlaylistId("__all_crates__");
+        setPlaylistOwnerId(null); // hides owner-only Recommendations
+        setCurrPlaylist(allTracks);
+        setPlaylistKeys(Array.from(featById.values()));
+        setShowPlaylist(true);
+        return;
+      }
+
+      // SoundCloud-inclusive selection → the combined browser (unified tracks).
+      const unified = [];
+      const seenSp = new Set();
+      await mapWithLimit(spotifyCrates, 4, async (c) => {
+        if (cancelAllRef.current) return;
+        const items = await fetchAllTracks(c.uid);
+        const feats = await fetchFeatures(items.map((it) => it.track.id));
+        const fById = new Map();
+        feats.forEach((f) => f && fById.set(f.id, f));
+        items.forEach((item) => {
+          if (seenSp.has(item.track.id)) return;
+          seenSp.add(item.track.id);
+          const raw = fById.get(item.track.id);
+          const feat = raw
+            ? { key: raw.key, mode: raw.mode, bpm: raw.tempo, energy: raw.energy }
+            : null;
+          unified.push(spotifyToUnified(item, feat));
+        });
         setAllProgress((p) => ({ ...p, done: p.done + 1 }));
-        return { tracks, features };
       });
 
-      // The user dismissed the loader mid-run — discard partial results.
+      const seenSc = new Set();
+      await mapWithLimit(scCratesSel, 4, async (c) => {
+        if (cancelAllRef.current) return;
+        const k = c.raw.kind;
+        const path =
+          k === "likes"
+            ? "/soundcloud/me/likes/tracks"
+            : k === "reposts"
+            ? "/soundcloud/me/reposts"
+            : "/soundcloud/playlists/" + encodeURIComponent(c.raw.id) + "/tracks";
+        const scTracks = await fetchScTracks(scFetch, path);
+        scTracks.forEach((tr) => {
+          const urn = tr.urn || String(tr.id);
+          if (seenSc.has(urn)) return;
+          seenSc.add(urn);
+          unified.push(soundcloudToUnified(tr, null));
+        });
+        setAllProgress((p) => ({ ...p, done: p.done + 1 }));
+      });
+
       if (cancelAllRef.current) return;
-
-      // Aggregate + dedupe by track id.
-      const seen = new Set();
-      const allTracks = [];
-      const featById = new Map();
-      perPlaylist.forEach(({ tracks, features }) => {
-        tracks.forEach((item) => {
-          if (!seen.has(item.track.id)) {
-            seen.add(item.track.id);
-            allTracks.push(item);
-          }
-        });
-        features.forEach((f) => {
-          if (f) featById.set(f.id, f);
-        });
-      });
-
-      setPlaylistName(
-        `${playlists.length} crate${playlists.length === 1 ? "" : "s"} · ${
-          allTracks.length
-        } tracks`
+      setCombinedTitle(
+        `${chosen.length} crate${chosen.length === 1 ? "" : "s"} · ${unified.length} tracks`
       );
-      setPlaylistId("__all_crates__");
-      setPlaylistOwnerId(null); // hides owner-only Recommendations
-      setCurrPlaylist(allTracks);
-      setPlaylistKeys(Array.from(featById.values()));
-      setShowPlaylist(true);
+      setCombinedTracks(unified);
     } catch (error) {
-      console.error("Failed to load all crates", error);
+      console.error("Failed to load selected crates", error);
     } finally {
       setLoadingAll(false);
     }
@@ -971,7 +1017,7 @@ let PLLibrary = (props) => {
       <Card
         key={crate.uid}
         className={classes.tileCard}
-        onClick={() => (isSc ? openScCrate(crate) : toggleSelect(crate.uid))}
+        onClick={() => toggleSelect(crate.uid)}
         style={{
           height: "100%",
           display: "flex",
@@ -1018,22 +1064,20 @@ let PLLibrary = (props) => {
             )}
             {isSc ? "SoundCloud" : "Spotify"}
           </span>
-          {/* Cross-search selection is Spotify-only (Phase 2 adds mixed sets). */}
-          {!isSc && (
-            <Checkbox
-              key={selected.has(crate.uid) ? "on" : "off"}
-              className={`${classes.tileCheckbox} ${
-                selected.has(crate.uid) ? classes.iconPop : ""
-              }`}
-              checked={selected.has(crate.uid)}
-              onClick={(e) => {
-                e.stopPropagation();
-                toggleSelect(crate.uid);
-              }}
-              title="Select for cross-search"
-              size="small"
-            />
-          )}
+          {/* Select for a combined open — Spotify + SoundCloud mix freely. */}
+          <Checkbox
+            key={selected.has(crate.uid) ? "on" : "off"}
+            className={`${classes.tileCheckbox} ${
+              selected.has(crate.uid) ? classes.iconPop : ""
+            }`}
+            checked={selected.has(crate.uid)}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleSelect(crate.uid);
+            }}
+            title="Select to open combined"
+            size="small"
+          />
           <IconButton
             className={classes.tileFav}
             size="small"
@@ -1550,9 +1594,7 @@ let PLLibrary = (props) => {
         </Box>
         <Box style={{ display: "flex", alignItems: "center", gap: 10 }}>
           {(() => {
-            const shownIds = sortedCrates
-              .filter((c) => c.source === "spotify")
-              .map((c) => c.uid);
+            const shownIds = sortedCrates.map((c) => c.uid);
             const allSelected =
               shownIds.length > 0 && shownIds.every((id) => selected.has(id));
             return (
@@ -1840,6 +1882,17 @@ let PLLibrary = (props) => {
           />
         )}
       </Dialog>
+
+      {/* Combined multi-source browser (a SoundCloud-inclusive Open(N)). */}
+      <CombinedCrate
+        open={Boolean(combinedTracks)}
+        onClose={() => setCombinedTracks(null)}
+        title={combinedTitle}
+        tracks={combinedTracks || []}
+        scFetch={scFetch}
+        updatePlayer={props.updatePlayer}
+        onPlaySoundcloud={props.onPlaySoundcloud}
+      />
     </>
   );
 };


### PR DESCRIPTION
Open a **SoundCloud-inclusive selection** of crates as **one table** mixing Spotify + SoundCloud tracks.

## `CombinedCrate.jsx` (new)
- **Source badge** per row (Spotify green / SoundCloud orange brand mark).
- **Superset columns:** Key + BPM shared (both have Camelot); **Energy/Released blank for SoundCloud**, **Genre blank for Spotify** — rendered as "—".
- **Per-source playback:** Spotify rows → Web Playback bar; SoundCloud rows → the Widget bar (both via the lifted player state from #76).
- SoundCloud rows keep an **"open on SoundCloud"** link.
- **Lazy SoundCloud key/BPM:** auto-analyzed on open via the shared `useScAnalysisQueue` (from #79) and overlaid live (sort/filter see the filled-in values).
- Search, sortable columns (Src/Track/Artist/Key/BPM/Energy/Length), pagination (100/page).

## `PLLibrary`
- SoundCloud crate tiles are now **selectable** (checkbox + card-click); the **Open** button still opens the single-crate view. **Select all** spans both sources.
- `handleOpenSelected` branches:
  - **Pure-Spotify** selection → the existing rich Playlist view (Recommendations, Set Builder, key filter) — unchanged.
  - **SoundCloud-inclusive** selection → fetch each crate's tracks (Spotify tracks + audio-features; SoundCloud tracks), normalize via `unifiedTrack`, open `CombinedCrate`.

## Not in this PR (→ 2c)
Harmonic **key filter** + **anchor highlighting** in the combined view (the harmonic-mixing polish). Cross-source **Set Builder** remains a later phase.

## Verification
- `eslint` clean on both files; `react-scripts build` compiles (only the pre-existing `Playlist.jsx` / `Recommendations.jsx` warnings).
- Worth a live look: select a Spotify + a SoundCloud crate → Open → one table with badges + superset columns; SoundCloud keys fill in; click a Spotify row (plays in the Spotify bar) then a SoundCloud row (plays in the Widget bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)