### PR TITLE
Batch B — Bottom player + Key Calculator + a11y (tweaks 14, 9c; 9d/9e investigated)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -121,6 +121,17 @@ const PLAYER_STYLES = {
 // The SoundCloud bar sits on TOP of the (always-mounted) Spotify player.
 const SC_PLAYER_WRAP_STYLE = { ...PLAYER_WRAP_STYLE, zIndex: 10000 };
 
+// Blur whatever has focus before opening a focus-untrapped dialog (the ones
+// with disableEnforceFocus: Key Calculator, Set Builder, Key-filter picker).
+// Otherwise the trigger button keeps focus while MUI aria-hides #root around
+// it, which Chrome flags: "Blocked aria-hidden on an element because its
+// descendant retained focus." Blurring first moves focus to <body>, outside
+// the aria-hidden subtree, so the warning never fires.
+const blurActive = () => {
+  const el = document.activeElement;
+  if (el && typeof el.blur === 'function') el.blur();
+};
+
 // Memoized so the Spotify Web Playback player only re-renders (and never
 // reconnects) when its own props change — not on every unrelated App re-render
 // like opening a drawer or dialog.
@@ -407,6 +418,7 @@ class App extends React.Component {
   }
 
   openKeyCalculator() {
+    blurActive();
     this.setState({
       showKeyCalculator: !this.state.showKeyCalculator,
     });
@@ -442,11 +454,13 @@ class App extends React.Component {
   }
 
   openSet() {
+    blurActive();
     this.setState({ setOpen: true });
   }
 
   // Replace the current set with a loaded saved set.
   loadSet(entries) {
+    blurActive();
     this.setState({ set: entries, setOpen: true });
   }
 
@@ -1253,6 +1267,9 @@ class App extends React.Component {
             <KeyCalculator
               open={this.state.showKeyCalculator}
               onClose={this.openKeyCalculator}
+              bottomInset={
+                this.state.scNowPlaying ? 130 : loggedIn ? 96 : 0
+              }
             />
           )}
 
@@ -1340,14 +1357,17 @@ class App extends React.Component {
 
           {/* The Spotify player stays mounted at all times — unmounting it
               tears down its Web Playback device ("Device not found"). While a
-              SoundCloud track plays, the SC widget overlays it (higher z-index)
-              and Spotify is paused. */}
+              SoundCloud track plays we HIDE it (display:none keeps the device
+              alive) so it no longer peeks out behind the shorter SC widget;
+              only the SC bar shows. Spotify is already paused on SC play. */}
           {loggedIn && (
-            <BottomPlayer
-              token={this.state.access_token}
-              uris={this.state.player.uris}
-              play={this.state.player.isPlaying}
-            />
+            <div style={{ display: this.state.scNowPlaying ? 'none' : 'block' }}>
+              <BottomPlayer
+                token={this.state.access_token}
+                uris={this.state.player.uris}
+                play={this.state.player.isPlaying}
+              />
+            </div>
           )}
           {this.state.scNowPlaying && (
             <ScBottomPlayer

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -767,7 +767,13 @@ let Playlist = (props) => {
                   variant="outlined"
                   size="small"
                   startIcon={<DonutLarge />}
-                  onClick={() => setPickerOpen(true)}
+                  // Blur the trigger before opening this focus-untrapped
+                  // (disableEnforceFocus) picker, so it isn't left focused
+                  // inside the aria-hidden root (Chrome aria-hidden warning).
+                  onClick={(e) => {
+                    e.currentTarget.blur();
+                    setPickerOpen(true);
+                  }}
                   style={{
                     height: "100%",
                     textTransform: "none",

--- a/client/src/utils/KeyCalculator.jsx
+++ b/client/src/utils/KeyCalculator.jsx
@@ -18,7 +18,11 @@ import { camelotColor, camelotInfo, compatibleCamelot } from "./harmonic";
 // Interactive key calculator: tap a key on the Camelot wheel to see it in all
 // three notations (Musical / Camelot / Open) at once, plus its harmonic matches.
 let KeyCalculator = (props) => {
-  const { onClose, open } = props;
+  // bottomInset = height (px) of the always-on bottom player bar, so the dialog
+  // centers in the box BETWEEN the top of the page and the top of the player
+  // instead of the full viewport (the player sits at a higher z-index and was
+  // covering/clipping the dialog's lower half — esp. on mobile).
+  const { onClose, open, bottomInset = 0 } = props;
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("xs"));
 
@@ -47,6 +51,10 @@ let KeyCalculator = (props) => {
       maxWidth="xs"
       disableEnforceFocus
       disableScrollLock
+      // Reserve the player's height at the bottom: the modal root ends above the
+      // player, so the centered (or fullScreen) paper + its max-height fit
+      // entirely in frame and the player can't overlap the content.
+      style={bottomInset ? { bottom: bottomInset } : undefined}
     >
       <DialogTitle
         disableTypography


### PR DESCRIPTION
**Batch B** of the QA-tweak pass — the bottom-player cleanup, Key Calculator positioning, and the aria-hidden console warning.

### Fixes (code)
| # | Fix | File |
|---|-----|------|
| **14a** | **Spotify player no longer peeks out behind the SoundCloud widget.** While a SC track plays, the Spotify `BottomPlayer` is wrapped in `display:none` — it stays **mounted** (so its Web Playback device survives; no "Device not found") but is hidden, so only the SC bar shows. | `App.js` |
| **14b** | **Key Calculator centers in the box between the page top and the player bar.** A `bottomInset` prop sets the modal root's `bottom` to the live player height (130 for the SC widget, 96 for the Spotify bar, 0 logged out), so the higher-z-index player can't overlap/clip the content — and it stays fully in frame on mobile (fullScreen) too. | `App.js`, `KeyCalculator.jsx` |
| **9c** | **aria-hidden focus warning silenced.** The three `disableEnforceFocus` dialogs (Key Calculator, Set Builder, Key-filter picker) left the trigger button focused while MUI aria-hides `#root`, which Chrome flags. We now blur the trigger (→ `<body>`) *before* opening, keeping the perf benefit of `disableEnforceFocus`. | `App.js`, `Playlist.jsx` |

### Investigated (no code — console-QA items 9d / 9e)
- **9d — Spotify web-playback `401`s (×3):** these come from inside the Spotify Web Playback SDK's device handshake/token probing, not our code. Playback works, so they're benign SDK retries. Silencing them would mean monkey-patching the SDK's `fetch` — not worth it. **Leave.**
- **9e — `requestMediaKeySystemAccess` robustness warning (`index.js:3`):** emitted by Spotify's SDK script (loaded at `index.js:3`) using EME/Widevine DRM for protected playback. Third-party, **not fixable by us. Leave.**

### Testing notes
- `npm start` compiles (the `CI=true` warnings are all pre-existing and unrelated).
- Try: play a SoundCloud track → no green Spotify bar peeking behind the SC widget. Open the **Key Calculator** with a track playing (Spotify *and* SoundCloud) → it sits fully above the player on desktop and mobile, nothing clipped. Watch the console while opening the Key Calculator / Set / Filter-by-Key → no aria-hidden warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)