### PR TITLE
Batch D — SoundCloud HLS analysis (fix the ~56 'couldn't analyze' tracks; tweak 6)

### DIFF
--- a/analysis-service/analyze.js
+++ b/analysis-service/analyze.js
@@ -25,10 +25,29 @@ const run = (cmd, args) =>
   execFileP(cmd, args, { maxBuffer: 1 << 26 }).then((r) => r.stdout.trim());
 
 // Decode to mono 44.1k WAV + a steady ~90s mid-segment (start at 25% in).
-async function decode(input, durationMs, dir) {
+// `headers` (an HLS auth header) is given to ffmpeg for REMOTE inputs so it can
+// fetch the m3u8 playlist + its segments itself; omitted for a local file.
+async function decode(input, durationMs, dir, headers) {
   const wav = path.join(dir, "a.wav");
   const seg = path.join(dir, "seg.wav");
-  await run(FFMPEG, ["-y", "-i", input, "-ac", "1", "-ar", "44100", wav]);
+  // For an HLS/remote input, let ffmpeg follow the playlist (a downloaded .m3u8
+  // has no base URL to resolve its segments). Whitelist the nested protocols
+  // and carry auth on every request.
+  const pre = headers
+    ? [
+        "-protocol_whitelist",
+        "file,http,https,tcp,tls,crypto",
+        "-headers",
+        `Authorization: ${headers}\r\n`,
+      ]
+    : [];
+  await run(FFMPEG, ["-y", ...pre, "-i", input, "-ac", "1", "-ar", "44100", wav]).catch(
+    () => {
+      const err = new Error("decode_failed");
+      err.code = "decode_failed";
+      throw err;
+    }
+  );
   const start = Math.max(20, Math.floor(((durationMs || 0) / 1000) * 0.25));
   await run(FFMPEG, ["-y", "-ss", String(start), "-t", "90", "-i", wav, "-ac", "1", seg]).catch(
     () => {}
@@ -58,12 +77,13 @@ function detectBpm(seg, genre) {
   });
 }
 
-// Analyze a local audio file path.
-async function analyzeFile(input, { durationMs, genre } = {}) {
+// Analyze a local file path OR a remote URL. `headers` is passed to ffmpeg for
+// remote (HLS) inputs so it can fetch the playlist + segments with auth.
+async function analyzeFile(input, { durationMs, genre, headers } = {}) {
   if (durationMs && durationMs > LIKELY_SET_MS) return { isLikelySet: true };
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kt-an-"));
   try {
-    const { wav, seg } = await decode(input, durationMs, dir);
+    const { wav, seg } = await decode(input, durationMs, dir, headers);
     const [key, bpm] = await Promise.all([detectKey(wav), detectBpm(seg, genre)]);
     return { isLikelySet: false, camelot: key.camelot, key: key.key, bpm };
   } finally {
@@ -71,10 +91,24 @@ async function analyzeFile(input, { durationMs, genre } = {}) {
   }
 }
 
-// Analyze a remote audio URL (downloads first, with an optional auth header —
-// SoundCloud stream URLs need `Authorization: OAuth <token>`).
-async function analyzeUrl(audioUrl, { authHeader, durationMs, genre } = {}) {
+// Does this URL look like an HLS playlist? SoundCloud's hls_* stream URLs
+// resolve to .m3u8 (sometimes behind a query string).
+function looksLikeHls(url) {
+  return /\.m3u8(\?|$)/i.test(url) || /(^|[?&/])hls/i.test(url);
+}
+
+// Analyze a remote audio URL. SoundCloud stream URLs need
+// `Authorization: OAuth <token>`.
+//   - Progressive MP3: download the bytes, then decode the local file.
+//   - HLS (m3u8): hand the URL straight to ffmpeg so it fetches the playlist +
+//     segments itself (a saved .m3u8 has no base URL to resolve them).
+async function analyzeUrl(audioUrl, { authHeader, durationMs, genre, isHls } = {}) {
   if (durationMs && durationMs > LIKELY_SET_MS) return { isLikelySet: true };
+
+  if (isHls || looksLikeHls(audioUrl)) {
+    return await analyzeFile(audioUrl, { durationMs, genre, headers: authHeader });
+  }
+
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kt-an-"));
   const file = path.join(dir, "in.audio");
   try {
@@ -82,7 +116,11 @@ async function analyzeUrl(audioUrl, { authHeader, durationMs, genre } = {}) {
       headers: authHeader ? { Authorization: authHeader } : {},
       redirect: "follow",
     });
-    if (!res.ok) throw new Error("download failed " + res.status);
+    if (!res.ok) {
+      const err = new Error("download_failed " + res.status);
+      err.code = "download_failed";
+      throw err;
+    }
     fs.writeFileSync(file, Buffer.from(await res.arrayBuffer()));
     return await analyzeFile(file, { durationMs, genre });
   } finally {

--- a/analysis-service/analyze.js
+++ b/analysis-service/analyze.js
@@ -52,7 +52,11 @@ async function decode(input, durationMs, dir, headers) {
   await run(FFMPEG, ["-y", "-ss", String(start), "-t", "90", "-i", wav, "-ac", "1", seg]).catch(
     () => {}
   );
-  return { wav, seg: fs.existsSync(seg) ? seg : wav };
+  // If the mid-segment is empty (e.g. a ~30s preview shorter than the 25%-in
+  // start offset), fall back to the full decoded wav so BPM still runs. An
+  // empty WAV is just its ~44-byte header; a real segment is far larger.
+  const segOk = fs.existsSync(seg) && fs.statSync(seg).size > 4096;
+  return { wav, seg: segOk ? seg : wav };
 }
 
 async function detectKey(wav) {

--- a/analysis-service/server.js
+++ b/analysis-service/server.js
@@ -1,6 +1,6 @@
 // KeyTrack analysis microservice.
-// POST /analyze { audioUrl, authHeader?, durationMs?, genre? }
-//   → { isLikelySet, camelot, key, bpm }
+// POST /analyze { audioUrl, authHeader?, durationMs?, genre?, isHls? }
+//   → { isLikelySet, camelot, key, bpm }  (or { error: <reason> } on failure)
 // Runs separately from the main backend (it needs ffmpeg + keyfinder-cli +
 // bpm-tools, which live in this service's container). The main app calls it
 // over HTTP.
@@ -21,14 +21,16 @@ app.post("/analyze", async (req, res) => {
   if (ANALYSIS_SECRET && req.headers["x-analysis-secret"] !== ANALYSIS_SECRET) {
     return res.status(401).send({ error: "unauthorized" });
   }
-  const { audioUrl, authHeader, durationMs, genre } = req.body || {};
+  const { audioUrl, authHeader, durationMs, genre, isHls } = req.body || {};
   if (!audioUrl) return res.status(400).send({ error: "audioUrl required" });
   try {
-    const result = await analyzeUrl(audioUrl, { authHeader, durationMs, genre });
+    const result = await analyzeUrl(audioUrl, { authHeader, durationMs, genre, isHls });
     res.send(result);
   } catch (e) {
-    console.error("analyze failed:", e.message);
-    res.status(500).send({ error: "analysis_failed" });
+    // Surface the specific reason (download_failed / decode_failed / …) so the
+    // backend + UI can show WHY, not just a generic failure.
+    console.error("analyze failed:", e.code || e.message);
+    res.status(500).send({ error: e.code || "analysis_failed" });
   }
 });
 

--- a/client/src/components/PLLibrary/CombinedPlaylist.jsx
+++ b/client/src/components/PLLibrary/CombinedPlaylist.jsx
@@ -109,7 +109,9 @@ let CombinedPlaylist = (props) => {
       const a = analysis[t.urn || String(t.id)];
       if (a && (a.camelot || a.isLikelySet || a.error)) {
         done += 1;
-        if (a.error) failed.push(t);
+        // Only RETRYABLE failures go in the Retry batch; "unavailable" tracks
+        // (SoundCloud-only / removed) can never be analyzed, so retrying is moot.
+        if (a.error && !a.unavailable) failed.push(t);
       }
     });
     return { total: scList.length, done, failed };
@@ -155,9 +157,13 @@ let CombinedPlaylist = (props) => {
     (scTracks || []).forEach((t) => {
       const urn = t.urn || String(t.id);
       const a = analysis[urn];
-      if (a && a.camelot) return;
+      // Analyzed tracks keep their real key; preview-derived ones get a marker.
+      if (a && a.camelot) {
+        if (a.preview) m[urn] = "preview";
+        return;
+      }
       if (a && a.isLikelySet) m[urn] = "set";
-      else if (a && a.error) m[urn] = "failed";
+      else if (a && a.error) m[urn] = a.unavailable ? "unavailable" : "failed";
       else m[urn] = "loading";
     });
     return m;

--- a/client/src/components/PLLibrary/CombinedPlaylist.jsx
+++ b/client/src/components/PLLibrary/CombinedPlaylist.jsx
@@ -107,11 +107,11 @@ let CombinedPlaylist = (props) => {
     const failed = [];
     scList.forEach((t) => {
       const a = analysis[t.urn || String(t.id)];
-      if (a && (a.camelot || a.isLikelySet || a.error)) {
+      if (a && (a.camelot || a.isLikelySet || a.error || a.unavailable)) {
         done += 1;
-        // Only RETRYABLE failures go in the Retry batch; "unavailable" tracks
+        // Only genuine failures are retryable; "unavailable" verdicts
         // (SoundCloud-only / removed) can never be analyzed, so retrying is moot.
-        if (a.error && !a.unavailable) failed.push(t);
+        if (a.error) failed.push(t);
       }
     });
     return { total: scList.length, done, failed };
@@ -163,7 +163,8 @@ let CombinedPlaylist = (props) => {
         return;
       }
       if (a && a.isLikelySet) m[urn] = "set";
-      else if (a && a.error) m[urn] = a.unavailable ? "unavailable" : "failed";
+      else if (a && a.unavailable) m[urn] = "unavailable";
+      else if (a && a.error) m[urn] = "failed";
       else m[urn] = "loading";
     });
     return m;

--- a/client/src/components/PLLibrary/Row.jsx
+++ b/client/src/components/PLLibrary/Row.jsx
@@ -223,7 +223,19 @@ let Row = (props) => {
       )}
       <TableCell>
         {keyInfo ? (
-          keyChip(keyLabel)
+          props.scStatus === "preview" ? (
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+              {keyChip(keyLabel)}
+              <span
+                title="Approximate — analyzed from a 30s SoundCloud preview"
+                style={{ color: "#ff5500", fontWeight: 700 }}
+              >
+                ~
+              </span>
+            </span>
+          ) : (
+            keyChip(keyLabel)
+          )
         ) : props.scStatus === "loading" ? (
           <span
             style={{
@@ -236,6 +248,21 @@ let Row = (props) => {
           >
             <CircularProgress size={12} style={{ color: "#ff5500" }} />
             analyzing…
+          </span>
+        ) : props.scStatus === "unavailable" ? (
+          <span
+            title="Only available on SoundCloud — no stream we can analyze"
+            style={{
+              backgroundColor: "rgba(0,0,0,0.08)",
+              color: "#666",
+              padding: "2px 8px",
+              borderRadius: 10,
+              fontSize: "0.72rem",
+              fontWeight: 700,
+              whiteSpace: "nowrap",
+            }}
+          >
+            SC-only
           </span>
         ) : props.scStatus === "failed" ? (
           <span

--- a/client/src/components/SoundCloud/SoundCloudCrate.jsx
+++ b/client/src/components/SoundCloud/SoundCloudCrate.jsx
@@ -437,14 +437,31 @@ let SoundCloudCrate = (props) => {
                           fontSize: "0.8rem",
                           whiteSpace: "nowrap",
                         }}
-                        title="Detected by KeyTrack"
+                        title={a.preview ? "Approximate — from a 30s SoundCloud preview" : "Detected by KeyTrack"}
                       >
                         {a.camelot}
                         {a.key ? " · " + a.key : ""}
                       </span>
+                      {a.preview && (
+                        <span
+                          title="Approximate — from a 30s SoundCloud preview"
+                          style={{ color: SC_ORANGE, fontWeight: 700, marginLeft: 4 }}
+                        >
+                          ~
+                        </span>
+                      )}
                     </TableCell>
                     <TableCell>{a.bpm || "—"}</TableCell>
                   </>
+                ) : a && a.error && a.unavailable ? (
+                  <TableCell colSpan={2}>
+                    <Chip
+                      size="small"
+                      label="SoundCloud-only"
+                      title="Only available on SoundCloud — no stream we can analyze"
+                      style={{ backgroundColor: "rgba(0,0,0,0.08)", color: "#666", height: 20, fontWeight: 700 }}
+                    />
+                  </TableCell>
                 ) : (
                   <>
                     <TableCell>{t.key_signature || "—"}</TableCell>

--- a/client/src/components/SoundCloud/SoundCloudCrate.jsx
+++ b/client/src/components/SoundCloud/SoundCloudCrate.jsx
@@ -453,7 +453,7 @@ let SoundCloudCrate = (props) => {
                     </TableCell>
                     <TableCell>{a.bpm || "—"}</TableCell>
                   </>
-                ) : a && a.error && a.unavailable ? (
+                ) : a && a.unavailable ? (
                   <TableCell colSpan={2}>
                     <Chip
                       size="small"

--- a/client/src/components/SoundCloud/useScAnalysisQueue.js
+++ b/client/src/components/SoundCloud/useScAnalysisQueue.js
@@ -40,7 +40,13 @@ export function useScAnalysisQueue(scFetch) {
               saveScAnalysis(urn, result);
             }
           } catch (e) {
-            result = { error: true };
+            // Capture the backend's specific reason (no_stream / decode_failed /
+            // download_failed / …) instead of a bare flag, so a failed track can
+            // show WHY rather than an indistinguishable error.
+            const data = e && e.response && e.response.data;
+            const reason =
+              (data && (data.reason || data.error)) || (e && e.message) || null;
+            result = { error: true, reason };
           }
         }
         setAnalysis((a) => ({ ...a, [urn]: result || { error: true } }));

--- a/client/src/components/SoundCloud/useScAnalysisQueue.js
+++ b/client/src/components/SoundCloud/useScAnalysisQueue.js
@@ -40,13 +40,17 @@ export function useScAnalysisQueue(scFetch) {
               saveScAnalysis(urn, result);
             }
           } catch (e) {
-            // Capture the backend's specific reason (no_stream / decode_failed /
-            // download_failed / …) instead of a bare flag, so a failed track can
-            // show WHY rather than an indistinguishable error.
+            // Capture the backend's specific reason instead of a bare flag, so a
+            // failed track can show WHY. `unavailable` (SoundCloud 403 "only on
+            // SoundCloud" / 404) marks tracks that can never be analyzed — a
+            // distinct, non-retryable state vs a transient failure.
             const data = e && e.response && e.response.data;
+            const status = data && data.scStatus;
             const reason =
-              (data && (data.reason || data.error)) || (e && e.message) || null;
-            result = { error: true, reason };
+              (data && (data.reason || data.scMessage || data.error)) ||
+              (e && e.message) ||
+              null;
+            result = { error: true, unavailable: status === 403 || status === 404, reason };
           }
         }
         setAnalysis((a) => ({ ...a, [urn]: result || { error: true } }));

--- a/client/src/components/SoundCloud/useScAnalysisQueue.js
+++ b/client/src/components/SoundCloud/useScAnalysisQueue.js
@@ -36,26 +36,32 @@ export function useScAnalysisQueue(scFetch) {
                 `&duration=${t.duration || 0}` +
                 `&genre=${encodeURIComponent(t.genre || "")}`
             );
-            if (result && !result.isLikelySet && result.camelot) {
+            // Cache successes AND terminal "unavailable" verdicts (a
+            // SoundCloud-only track won't become analyzable) so we don't re-hit
+            // the API for them.
+            if (result && !result.isLikelySet && (result.camelot || result.unavailable)) {
               saveScAnalysis(urn, result);
             }
           } catch (e) {
-            // Capture the backend's specific reason instead of a bare flag, so a
-            // failed track can show WHY. `unavailable` (SoundCloud 403 "only on
-            // SoundCloud" / 404) marks tracks that can never be analyzed — a
-            // distinct, non-retryable state vs a transient failure.
+            // A thrown error is now only a genuine/transient failure — the
+            // backend returns 200 for expected "unavailable" tracks. Capture the
+            // reason so the marker can show why.
             const data = e && e.response && e.response.data;
-            const status = data && data.scStatus;
             const reason =
               (data && (data.reason || data.scMessage || data.error)) ||
               (e && e.message) ||
               null;
-            result = { error: true, unavailable: status === 403 || status === 404, reason };
+            result = { error: true, reason };
           }
         }
         setAnalysis((a) => ({ ...a, [urn]: result || { error: true } }));
-        // Failed (e.g. HLS-only / no progressive stream) → allow a retry later.
-        if (!result || result.error || (!result.camelot && !result.isLikelySet)) {
+        // Allow a retry only for genuine failures or an analyzed-but-no-key
+        // result — NOT for terminal `unavailable` verdicts.
+        if (
+          !result ||
+          result.error ||
+          (!result.camelot && !result.isLikelySet && !result.unavailable)
+        ) {
           seenRef.current.delete(urn);
         }
       }

--- a/local-server/index.js
+++ b/local-server/index.js
@@ -499,9 +499,36 @@ app.get(
         if (err || !streams) {
           return res.status(502).send({ error: 'stream_lookup_failed' });
         }
-        const audioUrl =
-          streams.http_mp3_128_url || streams.hls_aac_160_url || null;
-        if (!audioUrl) return res.status(422).send({ error: 'no_stream' });
+        // Prefer a progressive MP3 (a simple download); otherwise fall back to
+        // ANY HLS variant the API exposes (mp3/aac/opus, or any other hls_*_url)
+        // and let the analysis service decode the playlist with ffmpeg.
+        // Previously we only checked http_mp3_128_url || hls_aac_160_url, so
+        // HLS-only tracks (which usually expose hls_mp3_128_url) returned
+        // no_stream — the bulk of the "couldn't analyze" failures.
+        const progressive = streams.http_mp3_128_url || null;
+        let hlsUrl = null;
+        if (!progressive) {
+          hlsUrl =
+            streams.hls_mp3_128_url ||
+            streams.hls_aac_160_url ||
+            streams.hls_opus_64_url ||
+            null;
+          if (!hlsUrl) {
+            const anyHls = Object.keys(streams).find(
+              (k) => /^hls_.*url$/i.test(k) && streams[k]
+            );
+            if (anyHls) hlsUrl = streams[anyHls];
+          }
+        }
+        const audioUrl = progressive || hlsUrl;
+        const isHls = !progressive && !!hlsUrl;
+        if (!audioUrl) {
+          // Surface what WAS available so genuinely streamless tracks are
+          // distinguishable from a selection gap.
+          return res
+            .status(422)
+            .send({ error: 'no_stream', available: Object.keys(streams || {}) });
+        }
         // 2) hand it to the analysis service
         request.post(
           {
@@ -512,13 +539,21 @@ app.get(
               authHeader: 'OAuth ' + token,
               durationMs,
               genre,
+              isHls,
             },
             timeout: 60000,
           },
           function (e2, r2, result) {
             if (e2 || !r2 || r2.statusCode !== 200) {
-              console.error('analysis service error', e2 && e2.message, r2 && r2.statusCode);
-              return res.status(502).send({ error: 'analysis_failed' });
+              // Pass the service's specific reason through so the UI/logs can
+              // show WHY (download_failed / decode_failed / …), not just a
+              // generic failure.
+              const reason =
+                (result && result.error) ||
+                (e2 && e2.message) ||
+                'analysis_failed';
+              console.error('analysis service error', reason, r2 && r2.statusCode);
+              return res.status(502).send({ error: 'analysis_failed', reason });
             }
             res.send(result);
           }

--- a/local-server/index.js
+++ b/local-server/index.js
@@ -497,7 +497,29 @@ app.get(
       },
       function (err, r, streams) {
         if (err || !streams) {
-          return res.status(502).send({ error: 'stream_lookup_failed' });
+          return res.status(502).send({
+            error: 'stream_lookup_failed',
+            reason: (err && err.message) || 'no_response',
+          });
+        }
+        // SoundCloud returns a JSON ERROR envelope (code/message/errors) on a
+        // non-2xx — e.g. 403 for tracks not streamable via the API, 404 for
+        // removed/region-locked tracks. Detect it instead of treating the
+        // envelope as a (streamless) streams object and mislabeling no_stream.
+        const scStatus = r && r.statusCode;
+        if (
+          (scStatus && scStatus >= 400) ||
+          streams.errors ||
+          streams.error ||
+          streams.code != null
+        ) {
+          const scMessage = streams.message || streams.error || null;
+          console.error('sc streams error', scStatus, scMessage, 'track', trackId);
+          return res.status(502).send({
+            error: 'stream_lookup_failed',
+            scStatus: scStatus || null,
+            scMessage,
+          });
         }
         // Prefer a progressive MP3 (a simple download); otherwise fall back to
         // ANY HLS variant the API exposes (mp3/aac/opus, or any other hls_*_url)
@@ -520,8 +542,14 @@ app.get(
             if (anyHls) hlsUrl = streams[anyHls];
           }
         }
-        const audioUrl = progressive || hlsUrl;
+        // Last resort: a 30s preview clip. Some tracks expose only
+        // preview_mp3_128_url to the API; analyze that and mark the result
+        // preview-based (approximate) rather than giving up.
+        const previewUrl =
+          !progressive && !hlsUrl ? streams.preview_mp3_128_url || null : null;
+        const audioUrl = progressive || hlsUrl || previewUrl;
         const isHls = !progressive && !!hlsUrl;
+        const isPreview = !progressive && !hlsUrl && !!previewUrl;
         if (!audioUrl) {
           // Surface what WAS available so genuinely streamless tracks are
           // distinguishable from a selection gap.
@@ -555,7 +583,12 @@ app.get(
               console.error('analysis service error', reason, r2 && r2.statusCode);
               return res.status(502).send({ error: 'analysis_failed', reason });
             }
-            res.send(result);
+            // Flag preview-derived results so the client can mark them approximate.
+            res.send(
+              isPreview && result && !result.error
+                ? { ...result, preview: true }
+                : result
+            );
           }
         );
       }

--- a/local-server/index.js
+++ b/local-server/index.js
@@ -514,6 +514,14 @@ app.get(
           streams.code != null
         ) {
           const scMessage = streams.message || streams.error || null;
+          // 403/404 = SoundCloud won't stream this track to our API token at all
+          // (monetized / "only available on SoundCloud" / removed). That's an
+          // EXPECTED "can't analyze" outcome, not a server error — return 200
+          // with an `unavailable` flag (so it doesn't spam the console with red
+          // 502s and gets cached), reserving 502 for genuine/transient errors.
+          if (scStatus === 403 || scStatus === 404) {
+            return res.send({ unavailable: true, scStatus, scMessage });
+          }
           console.error('sc streams error', scStatus, scMessage, 'track', trackId);
           return res.status(502).send({
             error: 'stream_lookup_failed',
@@ -551,11 +559,14 @@ app.get(
         const isHls = !progressive && !!hlsUrl;
         const isPreview = !progressive && !hlsUrl && !!previewUrl;
         if (!audioUrl) {
-          // Surface what WAS available so genuinely streamless tracks are
-          // distinguishable from a selection gap.
-          return res
-            .status(422)
-            .send({ error: 'no_stream', available: Object.keys(streams || {}) });
+          // No usable stream at all (not even a preview) — also an expected
+          // "can't analyze" outcome, not an error. 200 + unavailable; `available`
+          // lists the stream keys SoundCloud returned, for debugging.
+          return res.send({
+            unavailable: true,
+            reason: 'no_stream',
+            available: Object.keys(streams || {}),
+          });
         }
         // 2) hand it to the analysis service
         request.post(


### PR DESCRIPTION
**Batch D** — make HLS-only SoundCloud tracks analyzable. These were the bulk of the `422` / "couldn't analyze" failures.

### Root cause (two bugs)
1. **Backend stream selection too narrow.** It only accepted `http_mp3_128_url || hls_aac_160_url`. Most HLS-only tracks expose **`hls_mp3_128_url`**, which wasn't checked → `422 no_stream`.
2. **Analysis service couldn't decode HLS even when handed it.** It `fetch`ed the `.m3u8` *text* and wrote it to a file, then gave ffmpeg a playlist with **no base URL** to resolve its segment list → decode failed.

### Fix
- **`local-server` (key-track2):** prefer a progressive MP3; otherwise fall back to **any** `hls_*_url` variant. Pass `isHls` to the analysis service, surface the available stream keys on `no_stream`, and pass the service's failure reason back to the client.
- **`analysis-service`:** for HLS, hand the **m3u8 URL straight to ffmpeg** (`-protocol_whitelist file,http,https,tcp,tls,crypto` + `-headers "Authorization: OAuth …"`) so ffmpeg fetches the playlist *and* its segments itself. Emit specific error codes (`download_failed` / `decode_failed`).
- **Frontend (`useScAnalysisQueue`):** store the real reason instead of a bare `{ error: true }` (sets up the "show why" marker in tweak 4).

The progressive-MP3 path (currently-working tracks) is unchanged.

### ⚠️ Can't be verified locally
HLS decode needs a live SoundCloud token + the native binaries (ffmpeg/keyfinder-cli/bpm-tools that live in the container), so I couldn't test it here. It needs **redeploying both services** and testing against them:
- analysis-service → `git subtree push --prefix analysis-service heroku-analysis master`
- key-track2 → `git subtree push --prefix local-server heroku-backend master`

Node syntax-checked; frontend compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)