### PR TITLE
Batch E — Cross-source sets: add SoundCloud tracks to sets (tweak 12)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1488,6 +1488,8 @@ class App extends React.Component {
             onClear={this.clearSet}
             userId={this.state.user_id}
             onLoadSet={this.loadSet}
+            updatePlayer={this.updatePlayer}
+            onPlaySoundcloud={this.playSoundcloudTrack}
           />
 
           {/* The Spotify player stays mounted at all times — unmounting it

--- a/client/src/components/PLLibrary/Row.jsx
+++ b/client/src/components/PLLibrary/Row.jsx
@@ -84,10 +84,11 @@ let Row = (props) => {
     </span>
   );
 
-  // Combined-view only: SoundCloud rows can't be added to the Spotify set, so
-  // the add button is suppressed; for no-__source (Spotify) rows it's unchanged.
+  // SoundCloud tracks can be added to sets too now (key + BPM only, no energy),
+  // so the add button shows for every source. `isSoundcloud` still drives the
+  // cover source badge below.
   const isSoundcloud = item.__source === "soundcloud";
-  const addButton = isSoundcloud ? null : (
+  const addButton = (
     <IconButton
       aria-label="add to set"
       size="small"

--- a/client/src/components/PLLibrary/SetBuilder.jsx
+++ b/client/src/components/PLLibrary/SetBuilder.jsx
@@ -22,7 +22,13 @@ import {
 } from "@material-ui/icons";
 
 import KeyMap from "../../utils/KeyMap";
-import { camelotColor, compatibleCamelot } from "../../utils/harmonic";
+import {
+  camelotColor,
+  compatibleCamelot,
+  camelotToKeyMode,
+} from "../../utils/harmonic";
+import { getScAnalysis } from "../../utils/scAnalysis";
+import { SpotifyIcon, SoundcloudIcon } from "../BrandIcons";
 import {
   fetchSets,
   saveSet,
@@ -31,7 +37,9 @@ import {
   deserializeTracks,
 } from "../../utils/sets";
 
-const codeOf = (k) => (k ? KeyMap[k.key].camelot[k.mode] : null);
+// Guard KeyMap: a Spotify key can be -1 (no key) so KeyMap[k.key] may be
+// undefined — return null instead of crashing the whole panel.
+const codeOf = (k) => (k && KeyMap[k.key] ? KeyMap[k.key].camelot[k.mode] : null);
 
 // The ordered set, shown in a slide-out panel (bottom sheet on mobile, right
 // drawer on desktop). Each entry is { item, key } so the set is self-contained
@@ -46,6 +54,8 @@ const SetBuilder = ({
   onClear,
   userId,
   onLoadSet,
+  updatePlayer,
+  onPlaySoundcloud,
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
@@ -116,9 +126,54 @@ const SetBuilder = ({
     }
   };
 
+  // Backfill key/BPM for SoundCloud entries added before analysis finished (or
+  // loaded from a saved set without a key) — look them up in the shared
+  // analysis cache. Keyed by the entry's track id (= the SC urn). Non-blocking:
+  // already-analyzed tracks resolve instantly, others stay "analyzing…".
+  const [scKeys, setScKeys] = React.useState({});
+  React.useEffect(() => {
+    let cancelled = false;
+    (set || []).forEach((entry) => {
+      const it = entry.item;
+      if (!it || it.__source !== "soundcloud") return;
+      if (entry.key && KeyMap[entry.key.key]) return; // already has a usable key
+      const urn = it.track.id;
+      if (!urn || scKeys[urn]) return;
+      getScAnalysis(urn).then((a) => {
+        if (cancelled || !a || !a.camelot) return;
+        const km = camelotToKeyMode(a.camelot);
+        if (!km) return;
+        setScKeys((m) =>
+          m[urn] ? m : { ...m, [urn]: { key: km.key, mode: km.mode, bpm: a.bpm } }
+        );
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [set]);
+
+  // Play a set entry through the right source: SoundCloud → the Widget bottom
+  // bar; Spotify → Web Playback.
+  const playEntry = (item) => {
+    if (item.__source === "soundcloud") {
+      if (onPlaySoundcloud && item.__scRaw) onPlaySoundcloud(item.__scRaw);
+    } else if (updatePlayer && item.track.uri) {
+      updatePlayer([item.track.uri], true);
+    }
+  };
+
   const rows = set.map((entry) => {
-    const k = entry.key;
-    return { item: entry.item, code: codeOf(k), bpm: k ? Math.round(k.bpm) : null };
+    let k = entry.key && KeyMap[entry.key.key] ? entry.key : null;
+    if (!k && entry.item.__source === "soundcloud") {
+      k = scKeys[entry.item.track.id] || null;
+    }
+    return {
+      item: entry.item,
+      code: codeOf(k),
+      bpm: k && k.bpm != null ? Math.round(k.bpm) : null,
+    };
   });
 
   const transition = (a, b) => {
@@ -261,17 +316,37 @@ const SetBuilder = ({
                         }}
                       />
                     )}
-                    <Box style={{ flex: 1, minWidth: 0 }}>
+                    <Box
+                      style={{ flex: 1, minWidth: 0, cursor: "pointer" }}
+                      onClick={() => playEntry(r.item)}
+                      title="Play"
+                    >
                       <Typography
                         variant="body2"
                         style={{
                           fontWeight: 600,
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 6,
                           overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
                         }}
                       >
-                        {r.item.track.name}
+                        <span style={{ flexShrink: 0, display: "inline-flex" }}>
+                          {r.item.__source === "soundcloud" ? (
+                            <SoundcloudIcon size={13} color="#ff5500" />
+                          ) : (
+                            <SpotifyIcon size={13} color="#1ED760" />
+                          )}
+                        </span>
+                        <span
+                          style={{
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {r.item.track.name}
+                        </span>
                       </Typography>
                       <Typography
                         variant="caption"
@@ -283,8 +358,8 @@ const SetBuilder = ({
                           display: "block",
                         }}
                       >
-                        {r.item.track.artists.map((a) => a.name).join(", ")} ·{" "}
-                        {r.bpm} BPM
+                        {r.item.track.artists.map((a) => a.name).join(", ")}
+                        {r.bpm != null ? ` · ${r.bpm} BPM` : " · analyzing…"}
                       </Typography>
                     </Box>
                     <IconButton

--- a/client/src/utils/sets.js
+++ b/client/src/utils/sets.js
@@ -20,15 +20,27 @@ import {
 // entries also persist their source + a MINIMAL raw track (the fields the Widget
 // player + now-playing need), so a reloaded set can still play them and resolve
 // their key from the analysis cache.
+// Firestore rejects `undefined`. The set only uses key/mode/bpm, and a
+// SoundCloud key has no danceability/valence (Spotify-only features) — which
+// would be `undefined` and break the save — so store just the three fields.
+const cleanKey = (k) =>
+  k
+    ? {
+        key: k.key != null ? k.key : null,
+        mode: k.mode != null ? k.mode : null,
+        bpm: k.bpm != null ? k.bpm : null,
+      }
+    : null;
+
 const serializeEntry = (entry) => {
   const t = entry.item.track;
   const rec = {
     id: t.id || null,
     uri: t.uri || null,
     name: t.name || "",
-    artists: (t.artists || []).map((a) => ({ name: a.name })),
+    artists: (t.artists || []).map((a) => ({ name: a.name || "" })),
     image: (t.album && t.album.images && t.album.images[0] && t.album.images[0].url) || null,
-    key: entry.key || null,
+    key: cleanKey(entry.key),
   };
   if (entry.item.__source === "soundcloud") {
     rec.source = "soundcloud";

--- a/client/src/utils/sets.js
+++ b/client/src/utils/sets.js
@@ -16,10 +16,13 @@ import {
 // on Firestore's project rules. Tightening them (Firebase Auth + rules) is a
 // separate hardening step.
 
-// SetBuilder entry ({ item, key }) -> compact storable record.
+// SetBuilder entry ({ item, key }) -> compact storable record. SoundCloud
+// entries also persist their source + a MINIMAL raw track (the fields the Widget
+// player + now-playing need), so a reloaded set can still play them and resolve
+// their key from the analysis cache.
 const serializeEntry = (entry) => {
   const t = entry.item.track;
-  return {
+  const rec = {
     id: t.id || null,
     uri: t.uri || null,
     name: t.name || "",
@@ -27,11 +30,29 @@ const serializeEntry = (entry) => {
     image: (t.album && t.album.images && t.album.images[0] && t.album.images[0].url) || null,
     key: entry.key || null,
   };
+  if (entry.item.__source === "soundcloud") {
+    rec.source = "soundcloud";
+    const raw = entry.item.__scRaw || {};
+    rec.sc = {
+      urn: raw.urn || null,
+      id: raw.id || null,
+      title: raw.title || t.name || "",
+      permalink_url: raw.permalink_url || null,
+      uri: raw.uri || null,
+      sharing: raw.sharing || null,
+      secret_uri: raw.secret_uri || null,
+      secret_token: raw.secret_token || null,
+      artwork_url: raw.artwork_url || null,
+      user: { username: (raw.user && raw.user.username) || "" },
+      duration: raw.duration || null,
+    };
+  }
+  return rec;
 };
 
 // Stored record -> SetBuilder entry, reconstructing the shape the UI expects.
-const deserializeTrack = (s) => ({
-  item: {
+const deserializeTrack = (s) => {
+  const item = {
     track: {
       id: s.id,
       uri: s.uri,
@@ -39,9 +60,13 @@ const deserializeTrack = (s) => ({
       artists: s.artists || [],
       album: { images: s.image ? [{ url: s.image }] : [] },
     },
-  },
-  key: s.key || null,
-});
+  };
+  if (s.source === "soundcloud") {
+    item.__source = "soundcloud";
+    item.__scRaw = s.sc || {};
+  }
+  return { item, key: s.key || null };
+};
 
 export const deserializeTracks = (tracks) =>
   (tracks || []).map(deserializeTrack);


### PR DESCRIPTION
**Batch E** — SoundCloud tracks can now go into Sets alongside Spotify ones (key + BPM only, no energy).

### What changed
| Area | Change |
|---|---|
| **`Row.jsx`** | The add-to-set **`+`** button now shows on SoundCloud rows (it was suppressed before). |
| **`SetBuilder.jsx`** | Source-aware: each row shows a **source badge** (green Spotify / orange SoundCloud) and is **clickable to play** through the right source — SoundCloud via the Widget bottom bar, Spotify via Web Playback. |
| **Non-blocking key/BPM** | A SC track added before its analysis finished shows **"analyzing…"** and **backfills** key+BPM from the shared analysis cache (`getScAnalysis`) when available; already-analyzed tracks show instantly. |
| **`sets.js`** | Saved sets now persist `source` + a minimal raw SC track, so a reloaded set can still **play** SC tracks and **resolve their key**. |
| **Crash guard** | `codeOf` guards `KeyMap[-1]` (Spotify "no key") so a mixed set can't crash the panel. |

Energy is untouched — the Set panel never displayed energy, so "key + BPM only for SoundCloud" needed no column changes. Transition checks (key compatibility + BPM jump) work for SC tracks the same as Spotify.

Supersedes the earlier "Set button shows, Spotify-only for now" decision.

### Testing notes
- From a **combined / mixed Open(N)** view (a SoundCloud-inclusive selection), hit `+` on a SoundCloud row → it appears in the Set with an orange SC badge and key/BPM (or "analyzing…").
- Click a SC set row → plays in the SoundCloud widget; click a Spotify row → Web Playback.
- Save a mixed set, reload it → SC tracks still play and show their key.
- `npm start` compiles (pre-existing `Playlist`/`Recommendations` warnings only).

(Single-SoundCloud-crate add-to-set comes with tweak 7 / Batch H, when that view routes through Playlist.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)