### PR TITLE
Batch G — Global SoundCloud analysis queue + floating progress indicator (tweak 4)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -69,6 +69,7 @@ import KeyCalculator from './utils/KeyCalculator';
 import SpotifyPlayer from 'react-spotify-web-playback';
 import SpotifyIcon from './components/SpotifyIcon';
 import { scWidgetSrc, scTrackUrl, loadScWidgetApi } from './utils/soundcloudCrates';
+import { ScAnalysisProvider } from './components/SoundCloud/ScAnalysis';
 import { makeAppTheme, THEME_STORAGE_KEY } from './theme';
 
 // Utils
@@ -1389,6 +1390,15 @@ class App extends React.Component {
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <div className="App">
+          {/* One app-level SoundCloud analysis queue + floating progress
+              indicator, so analysis keeps running after a crate is closed. */}
+          <ScAnalysisProvider
+            token={this.state.soundcloud.access_token}
+            connected={this.state.soundcloud.connected}
+            backend={soundcloudBackend}
+            onRefreshToken={this.refreshSoundcloudToken}
+            playerInset={this.state.scNowPlaying ? 130 : loggedIn ? 96 : 0}
+          >
           {loggedIn ? (
             <>
               {this.renderHome(version)}
@@ -1511,6 +1521,7 @@ class App extends React.Component {
             // (updatePlayer), and playing another SC track just swaps.
             <ScBottomPlayer track={this.state.scNowPlaying} />
           )}
+          </ScAnalysisProvider>
         </div>
       </ThemeProvider>
     );

--- a/client/src/components/PLLibrary/CombinedPlaylist.jsx
+++ b/client/src/components/PLLibrary/CombinedPlaylist.jsx
@@ -3,7 +3,7 @@ import { CircularProgress, Button } from "@material-ui/core";
 
 import Playlist from "./Playlist";
 import { camelotToKeyMode } from "../../utils/harmonic";
-import { useScAnalysisQueue } from "../SoundCloud/useScAnalysisQueue";
+import { useScAnalysis } from "../SoundCloud/ScAnalysis";
 
 // Parse a SoundCloud date string into the Spotify album.release_date shape so a
 // SoundCloud track reuses the exact same release-date formatting as Spotify
@@ -35,7 +35,6 @@ let CombinedPlaylist = (props) => {
     spotifyItems,
     spotifyFeatures,
     scTracks,
-    scFetch,
     token,
     userId,
     updatePlayer,
@@ -45,7 +44,9 @@ let CombinedPlaylist = (props) => {
     setCount,
   } = props;
 
-  const { analysis, enqueueAll } = useScAnalysisQueue(scFetch);
+  // The app-level shared queue (so analysis continues after close + a global
+  // indicator shows progress).
+  const { analysis, enqueueAll } = useScAnalysis();
 
   // Auto-analyze the SoundCloud tracks on open so their key/BPM fill in live.
   React.useEffect(() => {

--- a/client/src/components/PLLibrary/CombinedPlaylist.jsx
+++ b/client/src/components/PLLibrary/CombinedPlaylist.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CircularProgress, Button } from "@material-ui/core";
+import { Button } from "@material-ui/core";
 
 import Playlist from "./Playlist";
 import { camelotToKeyMode } from "../../utils/harmonic";
@@ -127,15 +127,11 @@ let CombinedPlaylist = (props) => {
     whiteSpace: "nowrap",
     marginRight: 8,
   };
+  // Live progress is shown by the GLOBAL floating indicator now (one source of
+  // truth), so the header only surfaces the "couldn't analyze + Retry"
+  // affordance once analysis has finished and some retryable failures remain.
   let combinedStatus = null;
-  if (scStatus && scStatus.done < scStatus.total) {
-    combinedStatus = (
-      <span style={statusWrap}>
-        <CircularProgress size={13} style={{ color: "#ff5500" }} />
-        analyzing SoundCloud… {scStatus.done}/{scStatus.total}
-      </span>
-    );
-  } else if (scStatus && scStatus.failed.length) {
+  if (scStatus && scStatus.done >= scStatus.total && scStatus.failed.length) {
     combinedStatus = (
       <span style={statusWrap}>
         {scStatus.failed.length} couldn't analyze

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -713,6 +713,32 @@ let PLLibrary = (props) => {
   // for now SoundCloud crates open individually.
   const openScCrate = (crate) => setScOpened(crate);
 
+  // Retry a Spotify API call on 429 (rate limit), honoring the Retry-After
+  // header. Opening many crates at once bursts past Spotify's limit; without
+  // this a single 429 would fail the whole Open(N) batch.
+  const spotifyRetry = async (fn, attempts = 6) => {
+    for (let i = 0; ; i++) {
+      try {
+        return await fn();
+      } catch (e) {
+        const status = (e && e.status) || (e && e.response && e.response.status);
+        if (status === 429 && i < attempts) {
+          let waitS = 1;
+          try {
+            const ra =
+              (e && e.getResponseHeader && e.getResponseHeader("Retry-After")) ||
+              (e && e.response && e.response.headers &&
+                e.response.headers["retry-after"]);
+            if (ra) waitS = parseInt(ra, 10) || 1;
+          } catch (_) {}
+          await new Promise((r) => setTimeout(r, (waitS + 0.5) * 1000));
+          continue;
+        }
+        throw e;
+      }
+    }
+  };
+
   // --- Cross-playlist search: load every crate's tracks into one virtual
   // playlist, then reuse the normal Playlist view to search/filter across them.
   const fetchAllTracks = async (playlistId) => {
@@ -720,10 +746,10 @@ let PLLibrary = (props) => {
     let offset = 0;
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const res = await spotifyWebApi.getPlaylistTracks(playlistId, {
-        offset,
-        limit: 100,
-      });
+      const off = offset; // per-iteration capture for the retry closure
+      const res = await spotifyRetry(() =>
+        spotifyWebApi.getPlaylistTracks(playlistId, { offset: off, limit: 100 })
+      );
       items = items.concat(res.items || []);
       if (!res.next) break;
       offset += 100;
@@ -734,8 +760,8 @@ let PLLibrary = (props) => {
   const fetchFeatures = async (ids) => {
     const out = [];
     for (let i = 0; i < ids.length; i += 100) {
-      const res = await spotifyWebApi.getAudioFeaturesForTracks(
-        ids.slice(i, i + 100)
+      const res = await spotifyRetry(() =>
+        spotifyWebApi.getAudioFeaturesForTracks(ids.slice(i, i + 100))
       );
       out.push(...(res.audio_features || []));
     }
@@ -914,10 +940,10 @@ let PLLibrary = (props) => {
           let offset = 0;
           // eslint-disable-next-line no-constant-condition
           while (true) {
-            const res = await spotifyWebApi.getMySavedTracks({
-              limit: 50,
-              offset,
-            });
+            const off = offset; // per-iteration capture for the retry closure
+            const res = await spotifyRetry(() =>
+              spotifyWebApi.getMySavedTracks({ limit: 50, offset: off })
+            );
             items = items.concat(res.items || []);
             if (!res.next) break;
             offset += 50;

--- a/client/src/components/SoundCloud/ScAnalysis.jsx
+++ b/client/src/components/SoundCloud/ScAnalysis.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+
+import { buildScFetch } from "../../utils/soundcloudCrates";
+import { useScAnalysisQueue } from "./useScAnalysisQueue";
+import ScAnalysisIndicator from "./ScAnalysisIndicator";
+
+// A single, app-level SoundCloud analysis queue shared by every view (the
+// combined browser, the standalone crate, analyze-on-play) via context. Because
+// the provider lives high in the tree (App) and stays mounted, analysis KEEPS
+// RUNNING after a crate is closed, and the floating indicator persists. The
+// `children` element is the same reference across the provider's own state
+// updates, so React bails out of re-rendering the app tree on each analysis
+// tick — only the indicator and the components that actually read this context
+// re-render.
+const ScAnalysisContext = React.createContext({
+  analysis: {},
+  enqueue: () => {},
+  enqueueAll: () => {},
+});
+
+export function useScAnalysis() {
+  return React.useContext(ScAnalysisContext);
+}
+
+export function ScAnalysisProvider({
+  token,
+  connected,
+  backend,
+  onRefreshToken,
+  playerInset,
+  children,
+}) {
+  // One SoundCloud fetcher for the whole queue; rebuilds only when the token
+  // rotates (rare) — its 401 handler self-refreshes in between.
+  const scFetch = React.useMemo(
+    () =>
+      connected && token
+        ? buildScFetch({ token, backend, onRefreshToken })
+        : null,
+    [connected, token, backend, onRefreshToken]
+  );
+
+  const { analysis, enqueue, enqueueAll, meta, progress } =
+    useScAnalysisQueue(scFetch);
+
+  // Only the enqueue API + analysis map go through context; identities are
+  // stable, so consumers only re-render when `analysis` actually changes.
+  const value = React.useMemo(
+    () => ({ analysis, enqueue, enqueueAll }),
+    [analysis, enqueue, enqueueAll]
+  );
+
+  return (
+    <ScAnalysisContext.Provider value={value}>
+      {children}
+      <ScAnalysisIndicator
+        analysis={analysis}
+        meta={meta}
+        progress={progress}
+        playerInset={playerInset}
+      />
+    </ScAnalysisContext.Provider>
+  );
+}

--- a/client/src/components/SoundCloud/ScAnalysisIndicator.jsx
+++ b/client/src/components/SoundCloud/ScAnalysisIndicator.jsx
@@ -1,0 +1,109 @@
+import React from "react";
+import {
+  Box,
+  Collapse,
+  CircularProgress,
+  IconButton,
+  LinearProgress,
+  Typography,
+  withStyles,
+} from "@material-ui/core";
+import { ExpandLess, ExpandMore } from "@material-ui/icons";
+
+// Orange (SoundCloud) determinate bar.
+const ScLinearProgress = withStyles({
+  colorPrimary: { backgroundColor: "rgba(255,85,0,0.18)" },
+  barColorPrimary: { backgroundColor: "#ff5500" },
+})(LinearProgress);
+
+// A small, non-blocking, always-on-top progress pill pinned bottom-right (above
+// the player bar). It reflects the GLOBAL SoundCloud analysis queue, so it stays
+// visible — and the analysis keeps running — even after the crate is closed.
+// Collapsed: spinner + done/total + %. Expanded (upward): a scrollable list of
+// the tracks still being analyzed. Hidden entirely when nothing is running.
+const ScAnalysisIndicator = ({ analysis, meta, progress, playerInset = 0 }) => {
+  const [expanded, setExpanded] = React.useState(false);
+
+  const total = (progress && progress.total) || 0;
+  const done = Math.min((progress && progress.done) || 0, total);
+  // Nothing analyzing → render nothing.
+  if (total === 0) return null;
+
+  const pct = total ? Math.round((done / total) * 100) : 0;
+  const pending = Object.keys(meta || {})
+    .filter((urn) => analysis[urn] && analysis[urn].status === "loading")
+    .map((urn) => meta[urn]);
+
+  return (
+    <Box
+      style={{
+        position: "fixed",
+        right: 12,
+        bottom: playerInset + 12,
+        zIndex: 10001,
+        width: 290,
+        maxWidth: "calc(100vw - 24px)",
+        backgroundColor: "#fff",
+        borderRadius: 10,
+        border: "1px solid rgba(0,0,0,0.08)",
+        boxShadow: "0 4px 18px rgba(0,0,0,0.22)",
+        overflow: "hidden",
+      }}
+    >
+      {/* List grows UPWARD (the box is anchored by its bottom edge). */}
+      <Collapse in={expanded}>
+        <Box style={{ maxHeight: 200, overflowY: "auto" }}>
+          {pending.length === 0 ? (
+            <Typography
+              variant="caption"
+              color="textSecondary"
+              style={{ display: "block", padding: "8px 12px" }}
+            >
+              Finishing up…
+            </Typography>
+          ) : (
+            pending.map((t) => (
+              <Box
+                key={t.urn}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "5px 12px",
+                }}
+              >
+                <CircularProgress size={11} style={{ color: "#ff5500" }} />
+                <Typography variant="caption" noWrap style={{ flex: 1 }} title={t.title}>
+                  {t.title || "Track"}
+                </Typography>
+              </Box>
+            ))
+          )}
+        </Box>
+      </Collapse>
+
+      <Box
+        onClick={() => setExpanded((v) => !v)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "8px 6px 8px 10px",
+          cursor: "pointer",
+        }}
+      >
+        <CircularProgress size={16} style={{ color: "#ff5500" }} />
+        <Typography variant="caption" style={{ flex: 1, fontWeight: 600 }}>
+          Analyzing SoundCloud… {done}/{total} ({pct}%)
+        </Typography>
+        <IconButton size="small" aria-label={expanded ? "collapse" : "expand"}>
+          {expanded ? <ExpandMore fontSize="small" /> : <ExpandLess fontSize="small" />}
+        </IconButton>
+      </Box>
+
+      <ScLinearProgress variant="determinate" value={pct} style={{ height: 3 }} />
+    </Box>
+  );
+};
+
+export default ScAnalysisIndicator;

--- a/client/src/components/SoundCloud/SoundCloudCrate.jsx
+++ b/client/src/components/SoundCloud/SoundCloudCrate.jsx
@@ -32,7 +32,7 @@ import {
 
 import { camelotColor } from "../../utils/harmonic";
 import { fetchScTracks } from "../../utils/soundcloudCrates";
-import { useScAnalysisQueue } from "./useScAnalysisQueue";
+import { useScAnalysis } from "./ScAnalysis";
 
 // SoundCloud's brand orange — keeps SoundCloud crates visually distinct from
 // Spotify's green (strict source separation).
@@ -119,9 +119,9 @@ let SoundCloudCrate = (props) => {
     [backend, token, onRefreshToken]
   );
 
-  // Lazy key/BPM analysis (SoundCloud has none) via the shared single-worker
-  // queue. Results fill in live and cache app-wide.
-  const { analysis, enqueue, enqueueAll } = useScAnalysisQueue(scFetch);
+  // Lazy key/BPM analysis (SoundCloud has none) via the app-level shared queue,
+  // so it continues after this crate is closed and feeds the global indicator.
+  const { analysis, enqueue, enqueueAll } = useScAnalysis();
 
   // Play a track → bottom-bar playback (lifted to App) + kick off analysis
   // (non-blocking). Local `playing` only highlights the active row.

--- a/client/src/components/SoundCloud/useScAnalysisQueue.js
+++ b/client/src/components/SoundCloud/useScAnalysisQueue.js
@@ -17,6 +17,14 @@ export function useScAnalysisQueue(scFetch) {
   const queueRef = React.useRef([]); // FIFO of tracks awaiting analysis
   const seenRef = React.useRef(new Set()); // urns already queued/done (dedupe)
   const processingRef = React.useRef(false);
+  // For the global progress indicator: track metadata (urn -> {urn,title,
+  // artist}) and a {done,total} counter for the CURRENT run, reset to 0/0 when
+  // the queue drains so the next batch starts fresh (not a cumulative session
+  // total).
+  const metaRef = React.useRef({});
+  const totalRef = React.useRef(0);
+  const doneRef = React.useRef(0);
+  const [progress, setProgress] = React.useState({ done: 0, total: 0 });
 
   const trackUrn = (t) => t.urn || String(t.id);
 
@@ -55,6 +63,8 @@ export function useScAnalysisQueue(scFetch) {
           }
         }
         setAnalysis((a) => ({ ...a, [urn]: result || { error: true } }));
+        doneRef.current += 1;
+        setProgress({ done: doneRef.current, total: totalRef.current });
         // Allow a retry only for genuine failures or an analyzed-but-no-key
         // result — NOT for terminal `unavailable` verdicts.
         if (
@@ -66,6 +76,10 @@ export function useScAnalysisQueue(scFetch) {
         }
       }
       processingRef.current = false;
+      // Run drained — reset the counter so the next batch starts at 0/0.
+      totalRef.current = 0;
+      doneRef.current = 0;
+      setProgress({ done: 0, total: 0 });
     })();
   }, [scFetch]);
 
@@ -78,8 +92,15 @@ export function useScAnalysisQueue(scFetch) {
         setAnalysis((a) => ({ ...a, [urn]: { isLikelySet: true } }));
         return;
       }
+      metaRef.current[urn] = {
+        urn,
+        title: t.title || "",
+        artist: (t.user && t.user.username) || "",
+      };
       setAnalysis((a) => ({ ...a, [urn]: { status: "loading" } }));
       queueRef.current.push(t);
+      totalRef.current += 1;
+      setProgress({ done: doneRef.current, total: totalRef.current });
       processQueue();
     },
     [processQueue]
@@ -90,5 +111,5 @@ export function useScAnalysisQueue(scFetch) {
     [enqueue]
   );
 
-  return { analysis, enqueue, enqueueAll };
+  return { analysis, enqueue, enqueueAll, meta: metaRef.current, progress };
 }


### PR DESCRIPTION
**Batch G** — analysis no longer stops when you close a crate, and there's a persistent, non-blocking progress indicator.

### The problem
The analysis queue lived in each view's hook (`useScAnalysisQueue` in `CombinedPlaylist` *and* `SoundCloudCrate`). Closing the single SoundCloud crate **unmounted** its queue (analysis stopped + setState-on-unmounted warnings), and the only progress UI was inside the crate header — gone the moment you closed it.

### The fix
One **app-level** queue shared via context (`ScAnalysisProvider`, mounted in `App`):
- **Analysis keeps running after close** — the provider stays mounted, so the queue drains to completion regardless of which crate is open.
- **Floating indicator** pinned bottom-right, **above the player bar**, non-blocking. Collapsed: spinner + `done/total (%)`. Click to expand a **scrollable list** of the tracks still analyzing. Hidden entirely when nothing's running.
- **Shared results** — a track analyzed in the combined view is instantly available in the single-crate view and vice-versa (one `analysis` map).

### Perf note
The provider sits high in the tree and its `children` element is referentially stable across the provider's own state updates, so React **bails out of re-rendering the app tree** (including PLLibrary and the Spotify Web Playback player) on every analysis tick — only the indicator and the components that actually read the context re-render.

Supporting change: `useScAnalysisQueue` now exposes `meta` (urn → title/artist for the list) and `progress` (`{done,total}`, reset to 0/0 when the queue drains so each batch starts fresh, not a cumulative session total).

### Decisions baked in (from earlier)
- **No per-track %** — each track is a single ~1.5s server call with no sub-progress, so the list shows a spinner + title per track and the pill shows overall `done/total + %`.
- **Global scope** — covers the combined browser, the standalone crate, and analyze-on-play.
- **In-memory** — a hard refresh resets it (already-done tracks are skipped via the Firestore cache on re-trigger).

### Testing notes
- Start analyzing a big crate → **close it** → the indicator stays bottom-right and keeps counting up to completion.
- Open a different crate while it runs → progress is shared.
- Expand the pill → see the list of in-flight tracks; it hides when done.
- Confirm playing/scrubbing Spotify + SoundCloud is unaffected while analysis churns (no player re-render).
- `npm start` compiles (pre-existing `Playlist`/`Recommendations` warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)