### PR TITLE
Speed-opt #1 + #2 — bulk SoundCloud cache read + persistent IndexedDB crate cache

### DIFF
--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -77,6 +77,7 @@ import {
   isLikelySet,
 } from "../../utils/soundcloudCrates";
 import { idbGet, idbSet } from "../../utils/crateStore";
+import { breakerWaitMs, note429, noteSuccess } from "../../utils/spotifyLimiter";
 
 // SoundCloud brand orange (source badge + toggle), distinct from Spotify green.
 const SC_ORANGE = "#ff5500";
@@ -471,6 +472,9 @@ let PLLibrary = (props) => {
   const [loadingId, setLoadingId] = React.useState(null);
   const [loadingAll, setLoadingAll] = React.useState(false);
   const [allProgress, setAllProgress] = React.useState({ done: 0, total: 0 });
+  // True while the Spotify circuit breaker is paused on a rate limit — shows a
+  // "pausing to recover" note in the loader instead of silently stalling.
+  const [rateLimited, setRateLimited] = React.useState(false);
   // Set when the user dismisses the "Search all crates" loader; in-flight and
   // queued fetches check this and bail so a big library doesn't trap them.
   const cancelAllRef = React.useRef(false);
@@ -739,24 +743,35 @@ let PLLibrary = (props) => {
     }
   };
 
-  // Retry a Spotify API call on 429 (rate limit), honoring the Retry-After
-  // header. Opening many crates at once bursts past Spotify's limit; without
-  // this a single 429 would fail the whole Open(N) batch.
-  const spotifyRetry = async (fn, attempts = 8) => {
+  // Retry a Spotify call on 429, backed by a CIRCUIT BREAKER. Spotify
+  // rate-limits per app and often omits Retry-After, so blind retries just keep
+  // the limit alive. After a few consecutive 429s the breaker opens; from then
+  // on each call WAITS OUT a cooldown (once, up front) instead of hammering,
+  // which lets the rate-limit window actually recover. A success closes it.
+  // Within a call we still do a few short, jittered backoff retries.
+  const spotifyRetry = async (fn, attempts = 3) => {
+    const cd = breakerWaitMs();
+    if (cd > 0) {
+      setRateLimited(true);
+      await new Promise((r) => setTimeout(r, cd));
+    }
     for (let i = 0; ; i++) {
       try {
-        return await fn();
+        const res = await fn();
+        noteSuccess();
+        setRateLimited(false);
+        return res;
       } catch (e) {
         const status = (e && e.status) || (e && e.response && e.response.status);
-        if (status === 429 && i < attempts) {
-          // Spotify doesn't expose Retry-After to browser JS (CORS) — reading it
-          // logs "Refused to get unsafe header" — so back off exponentially with
-          // jitter instead. Jitter de-syncs the parallel workers so they don't
-          // all re-burst at the same instant. 1.5s → 3 → 6 → 12 → 20s (capped).
-          const base = Math.min(20000, 1500 * Math.pow(2, i));
-          const waitMs = Math.round(base * (0.7 + Math.random() * 0.6));
-          await new Promise((r) => setTimeout(r, waitMs));
-          continue;
+        if (status === 429) {
+          note429(); // may open the breaker for subsequent calls
+          if (i < attempts) {
+            const base = Math.min(20000, 1500 * Math.pow(2, i));
+            await new Promise((r) =>
+              setTimeout(r, Math.round(base * (0.7 + Math.random() * 0.6)))
+            );
+            continue;
+          }
         }
         throw e;
       }
@@ -879,6 +894,7 @@ let PLLibrary = (props) => {
     const scCratesSel = chosen.filter((c) => c.source === "soundcloud");
 
     cancelAllRef.current = false;
+    setRateLimited(false);
     setAllProgress({ done: 0, total: chosen.length });
     setLoadingAll(true);
     try {
@@ -1562,6 +1578,14 @@ let PLLibrary = (props) => {
           Loading all crates…
         </Typography>
         <FillBar done={allProgress.done} total={allProgress.total} />
+        {rateLimited && (
+          <Typography
+            variant="caption"
+            style={{ color: "#e08a1e", fontWeight: 600, textAlign: "center" }}
+          >
+            Spotify is rate-limiting — pausing to let it recover…
+          </Typography>
+        )}
       </Dialog>
 
       <Box

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -76,6 +76,7 @@ import {
   fetchScTracks,
   isLikelySet,
 } from "../../utils/soundcloudCrates";
+import { idbGet, idbSet } from "../../utils/crateStore";
 
 // SoundCloud brand orange (source badge + toggle), distinct from Spotify green.
 const SC_ORANGE = "#ff5500";
@@ -690,7 +691,10 @@ let PLLibrary = (props) => {
 
     try {
       // Cached by uid — instant on a re-open this session.
-      const { items, features } = await getSpotifyCrate(crate.uid);
+      const { items, features } = await getSpotifyCrate(
+        crate.uid,
+        crate.raw && crate.raw.snapshot_id
+      );
       setCurrPlaylist(items);
       setPlaylistKeys(features);
       setShowPlaylist(true);
@@ -788,25 +792,41 @@ let PLLibrary = (props) => {
     return out;
   };
 
-  // Run `fetcher` once per cache key, reusing the result for the rest of the
-  // session. Failures aren't cached (the throw happens before the set).
-  const cachedCrate = async (key, fetcher) => {
-    const hit = crateCacheRef.current.get(key);
-    if (hit) return hit;
-    const val = await fetcher();
-    crateCacheRef.current.set(key, val);
-    return val;
+  // Run `fetcher` once per cache key, reusing the result across the session AND
+  // (when a `version` token is given) across browser restarts via IndexedDB.
+  // `version` is a freshness token (Spotify snapshot_id / SoundCloud track-count)
+  // — a stored entry is only reused when its version still matches, so an edited
+  // crate auto-refetches. A falsy version means in-memory only (don't persist).
+  // Failures aren't cached (the throw happens before the set).
+  const cachedCrate = async (key, version, fetcher) => {
+    const mem = crateCacheRef.current.get(key);
+    if (mem && mem.__v === version) return mem.data;
+    if (version) {
+      const persisted = await idbGet(key);
+      if (persisted && persisted.__v === version) {
+        crateCacheRef.current.set(key, persisted);
+        return persisted.data;
+      }
+    }
+    const data = await fetcher();
+    const rec = { __v: version, data };
+    crateCacheRef.current.set(key, rec);
+    if (version) idbSet(key, rec);
+    return data;
   };
 
-  // A Spotify crate's tracks + audio features, cached by uid.
-  const getSpotifyCrate = (uid) =>
-    cachedCrate(`sp:${uid}`, async () => {
+  // A Spotify crate's tracks + audio features, cached by uid + snapshot_id (so
+  // an edited playlist auto-refetches).
+  const getSpotifyCrate = (uid, snapshot) =>
+    cachedCrate(`sp:${uid}`, snapshot || null, async () => {
       const items = await fetchAllTracks(uid);
       const features = await fetchFeatures(items.map((t) => t.track.id));
       return { items, features };
     });
 
-  // A SoundCloud crate's full track list, cached by uid.
+  // A SoundCloud crate's full track list, cached by uid. Playlists persist
+  // (keyed by track-count); likes/reposts stay in-memory only (their counts grow
+  // and the count we have is only the first page — persisting would go stale).
   const getScCrate = async (c) => {
     const k = c.raw.kind;
     const path =
@@ -815,7 +835,8 @@ let PLLibrary = (props) => {
         : k === "reposts"
         ? "/soundcloud/me/reposts"
         : "/soundcloud/playlists/" + encodeURIComponent(c.raw.id) + "/tracks";
-    const { tracks } = await cachedCrate(`sc:${c.uid}`, async () => ({
+    const version = k === "playlist" && c.count != null ? `n${c.count}` : null;
+    const { tracks } = await cachedCrate(`sc:${c.uid}`, version, async () => ({
       tracks: await fetchScTracks(scFetch, path),
     }));
     return tracks;
@@ -866,7 +887,10 @@ let PLLibrary = (props) => {
       if (scCratesSel.length === 0) {
         const perPlaylist = await mapWithLimit(spotifyCrates, 3, async (c) => {
           if (cancelAllRef.current) return { tracks: [], features: [] };
-          const { items, features } = await getSpotifyCrate(c.uid);
+          const { items, features } = await getSpotifyCrate(
+            c.uid,
+            c.raw && c.raw.snapshot_id
+          );
           setAllProgress((p) => ({ ...p, done: p.done + 1 }));
           return { tracks: items, features };
         });
@@ -905,7 +929,10 @@ let PLLibrary = (props) => {
       const featById = new Map();
       await mapWithLimit(spotifyCrates, 3, async (c) => {
         if (cancelAllRef.current) return;
-        const { items, features: feats } = await getSpotifyCrate(c.uid);
+        const { items, features: feats } = await getSpotifyCrate(
+          c.uid,
+          c.raw && c.raw.snapshot_id
+        );
         feats.forEach((f) => f && featById.set(f.id, f));
         items.forEach((item) => {
           if (seenSp.has(item.track.id)) return;
@@ -955,6 +982,7 @@ let PLLibrary = (props) => {
       // of re-paging the whole saved-tracks library.
       const { items: tracks, features } = await cachedCrate(
         "sp:__liked__",
+        null,
         async () => {
           let items = [];
           let offset = 0;

--- a/client/src/components/SoundCloud/useScAnalysisQueue.js
+++ b/client/src/components/SoundCloud/useScAnalysisQueue.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { getScAnalysis, saveScAnalysis } from "../../utils/scAnalysis";
+import { getScAnalysis, getScAnalysisBulk, saveScAnalysis } from "../../utils/scAnalysis";
 import { isLikelySet } from "../../utils/soundcloudCrates";
 
 // A single-worker FIFO queue that lazily computes our key/BPM for SoundCloud
@@ -106,9 +106,52 @@ export function useScAnalysisQueue(scFetch) {
     [processQueue]
   );
 
+  // Enqueue many tracks fast: bulk-read the shared cache in PARALLEL up front,
+  // paint cache hits instantly, and only feed the cache MISSES into the
+  // single-worker server queue. (Going through enqueue() one-by-one would do N
+  // serial cache reads — slow for an already-analyzed crate.)
   const enqueueAll = React.useCallback(
-    (tracks) => (tracks || []).forEach(enqueue),
-    [enqueue]
+    async (tracks) => {
+      const fresh = [];
+      (tracks || []).forEach((t) => {
+        const urn = trackUrn(t);
+        if (seenRef.current.has(urn)) return;
+        seenRef.current.add(urn);
+        if (isLikelySet(t.duration)) {
+          setAnalysis((a) => ({ ...a, [urn]: { isLikelySet: true } }));
+        } else {
+          fresh.push(t);
+        }
+      });
+      if (!fresh.length) return;
+
+      const cached = await getScAnalysisBulk(fresh.map(trackUrn));
+      const misses = [];
+      const hitUpdates = {};
+      fresh.forEach((t) => {
+        const urn = trackUrn(t);
+        if (cached[urn]) {
+          hitUpdates[urn] = cached[urn];
+        } else {
+          misses.push(t);
+          hitUpdates[urn] = { status: "loading" };
+          metaRef.current[urn] = {
+            urn,
+            title: t.title || "",
+            artist: (t.user && t.user.username) || "",
+          };
+        }
+      });
+      setAnalysis((a) => ({ ...a, ...hitUpdates }));
+
+      if (misses.length) {
+        misses.forEach((t) => queueRef.current.push(t));
+        totalRef.current += misses.length;
+        setProgress({ done: doneRef.current, total: totalRef.current });
+        processQueue();
+      }
+    },
+    [processQueue]
   );
 
   return { analysis, enqueue, enqueueAll, meta: metaRef.current, progress };

--- a/client/src/utils/crateStore.js
+++ b/client/src/utils/crateStore.js
@@ -1,0 +1,58 @@
+// Tiny IndexedDB key/value store for the persistent crate cache (track lists +
+// audio features). IndexedDB (not localStorage) because the values are large
+// and structured — it handles MBs of objects via structured clone, no JSON.
+// Every value is wrapped as { __v, data } where __v is a version token
+// (Spotify snapshot_id / SoundCloud track-count) so a stale crate auto-refetches
+// when it actually changed. All ops fail silently (offline / private mode).
+
+const DB_NAME = "keytrack";
+const STORE = "crates";
+let dbPromise = null;
+
+function openDb() {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve, reject) => {
+    try {
+      const req = indexedDB.open(DB_NAME, 1);
+      req.onupgradeneeded = () => {
+        if (!req.result.objectStoreNames.contains(STORE)) {
+          req.result.createObjectStore(STORE);
+        }
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    } catch (e) {
+      reject(e);
+    }
+  });
+  return dbPromise;
+}
+
+export async function idbGet(key) {
+  try {
+    const db = await openDb();
+    return await new Promise((resolve) => {
+      const tx = db.transaction(STORE, "readonly");
+      const r = tx.objectStore(STORE).get(key);
+      r.onsuccess = () => resolve(r.result || null);
+      r.onerror = () => resolve(null);
+    });
+  } catch (e) {
+    return null;
+  }
+}
+
+export async function idbSet(key, val) {
+  try {
+    const db = await openDb();
+    await new Promise((resolve) => {
+      const tx = db.transaction(STORE, "readwrite");
+      tx.objectStore(STORE).put(val, key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => resolve();
+      tx.onabort = () => resolve();
+    });
+  } catch (e) {
+    // ignore (quota / private mode) — falls back to the in-memory cache
+  }
+}

--- a/client/src/utils/scAnalysis.js
+++ b/client/src/utils/scAnalysis.js
@@ -1,4 +1,14 @@
-import { getFirestore, doc, getDoc, setDoc } from "firebase/firestore";
+import {
+  getFirestore,
+  doc,
+  getDoc,
+  setDoc,
+  collection,
+  getDocs,
+  query,
+  where,
+  documentId,
+} from "firebase/firestore";
 
 // Shared cache of our computed SoundCloud key/BPM, keyed by track URN and
 // shared across all users (it's analysis of public tracks). A track is only
@@ -21,6 +31,43 @@ export async function getScAnalysis(urn) {
   } catch (e) {
     return null; // offline / rules / not-initialized → just skip the cache
   }
+}
+
+// Bulk-read cached analyses for many urns in PARALLEL, returning { [urn]: data }
+// for the hits. Opening a crate of already-analyzed tracks previously did N
+// SERIAL getDoc reads through the single-worker queue (~seconds); this does it
+// in a handful of `documentId() in` queries (≤30 ids each) run concurrently.
+export async function getScAnalysisBulk(urns) {
+  const out = {};
+  const ids = [];
+  const idToUrn = {};
+  (urns || []).forEach((u) => {
+    const id = keyId(u);
+    if (!idToUrn[id]) {
+      idToUrn[id] = u;
+      ids.push(id);
+    }
+  });
+  if (!ids.length) return out;
+  try {
+    const col = collection(getFirestore(), "scAnalysis");
+    const chunks = [];
+    for (let i = 0; i < ids.length; i += 30) chunks.push(ids.slice(i, i + 30));
+    const snaps = await Promise.all(
+      chunks.map((c) => getDocs(query(col, where(documentId(), "in", c))))
+    );
+    snaps.forEach((snap) =>
+      snap.forEach((docSnap) => {
+        const d = docSnap.data();
+        if (d && d.engineVersion === ENGINE_VERSION) {
+          out[idToUrn[docSnap.id] || docSnap.id] = d;
+        }
+      })
+    );
+  } catch (e) {
+    // Any failure → return whatever hits we have; the queue analyzes the rest.
+  }
+  return out;
 }
 
 export async function saveScAnalysis(urn, data) {

--- a/client/src/utils/spotifyLimiter.js
+++ b/client/src/utils/spotifyLimiter.js
@@ -1,0 +1,34 @@
+// A tiny circuit breaker for Spotify API calls. Spotify rate-limits per app
+// (client id) and — as seen in practice — some 429s come back with NO
+// Retry-After header, so blind retries just keep the limit alive. After
+// OPEN_AFTER consecutive 429s we OPEN the breaker for COOLDOWN_MS: callers wait
+// out the cooldown instead of hammering, then a single success closes it again.
+// Module-level so it's shared across every Spotify request in the session.
+
+const OPEN_AFTER = 3;
+const COOLDOWN_MS = 60000;
+
+let consecutive429 = 0;
+let openUntil = 0; // epoch ms the breaker stays open until
+
+// Ms remaining on an open breaker (0 = closed).
+export function breakerWaitMs() {
+  const now = Date.now();
+  return openUntil > now ? openUntil - now : 0;
+}
+
+// Record a 429. Returns true if this tripped the breaker open.
+export function note429() {
+  consecutive429 += 1;
+  if (consecutive429 >= OPEN_AFTER && openUntil <= Date.now()) {
+    openUntil = Date.now() + COOLDOWN_MS;
+    return true;
+  }
+  return false;
+}
+
+// Record a success — closes the breaker.
+export function noteSuccess() {
+  consecutive429 = 0;
+  openUntil = 0;
+}


### PR DESCRIPTION
First speed-optimization batch — the two caching wins.

### #1 · SoundCloud cached-analysis loads instantly
The analysis queue is a single-worker FIFO, so opening a crate of *already-analyzed* tracks read the Firestore cache **one track at a time** (~N serial reads = several seconds), even though every one was a hit.
- `getScAnalysisBulk()` reads many urns **in parallel** via chunked `documentId() in` queries (≤30 ids/chunk).
- `enqueueAll()` now bulk-reads the cache up front, **paints hits immediately**, and only feeds cache *misses* into the single-worker server queue.

→ An already-analyzed crate now fills in a couple of parallel round-trips instead of N serial ones.

### #2 · Crate cache survives browser restarts
The crate cache (track-lists + audio-features) was in-memory only (gone on refresh/close).
- New `crateStore.js` — a tiny **IndexedDB** key/value store (structured clone, no `localStorage` size limits; fails silently in private mode).
- `cachedCrate(key, version, fetcher)` layers IndexedDB under the in-memory map, keyed with a freshness **version** token:
  - **Spotify crates** → `uid + snapshot_id` (Spotify bumps `snapshot_id` on any edit → auto-refetch only when the playlist actually changed — persistent *and* never stale).
  - **SoundCloud playlists** → track-count.
  - **Liked Songs / likes / reposts** → `null` version = in-memory only (no reliable freshness token, so we don't persist and risk stale data).
  - One entry per crate, overwritten on version change → no orphan accumulation.

### Testing notes
- **#1:** open a SoundCloud (or mixed) crate you've already analyzed → keys/BPM should fill near-instantly instead of trickling in.
- **#2:** open a Spotify crate → **refresh the page** → re-open it → instant (from IndexedDB). Then edit that playlist in Spotify (add/remove a track) → re-open → it refetches. Liked Songs still reloads each session (by design).
- `npm start` compiles (pre-existing `Playlist`/`Recommendations` warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)