### PR TITLE
Speed-opt #6 — proactive Spotify request pacing

### DIFF
--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -77,7 +77,12 @@ import {
   isLikelySet,
 } from "../../utils/soundcloudCrates";
 import { idbGet, idbSet } from "../../utils/crateStore";
-import { breakerWaitMs, note429, noteSuccess } from "../../utils/spotifyLimiter";
+import {
+  breakerWaitMs,
+  note429,
+  noteSuccess,
+  throttleSlot,
+} from "../../utils/spotifyLimiter";
 
 // SoundCloud brand orange (source badge + toggle), distinct from Spotify green.
 const SC_ORANGE = "#ff5500";
@@ -757,6 +762,9 @@ let PLLibrary = (props) => {
     }
     for (let i = 0; ; i++) {
       try {
+        // Proactive pacing: space requests globally so we mostly stay UNDER the
+        // limit (the breaker above is the reactive backstop).
+        await throttleSlot();
         const res = await fn();
         noteSuccess();
         setRateLimited(false);

--- a/client/src/utils/spotifyLimiter.js
+++ b/client/src/utils/spotifyLimiter.js
@@ -32,3 +32,20 @@ export function noteSuccess() {
   consecutive429 = 0;
   openUntil = 0;
 }
+
+// --- Proactive pacing ----------------------------------------------------
+// A global "next slot" scheduler that spaces consecutive Spotify requests at
+// least MIN_GAP_MS apart, so we mostly stay UNDER the rate limit instead of
+// tripping it and relying on the breaker to recover. This caps the global rate
+// regardless of how many crate workers run concurrently. await it before each
+// request.
+const MIN_GAP_MS = 150; // ~6-7 requests/sec
+
+let nextSlot = 0;
+export function throttleSlot() {
+  const now = Date.now();
+  const slot = Math.max(now, nextSlot);
+  nextSlot = slot + MIN_GAP_MS;
+  const wait = slot - now;
+  return wait > 0 ? new Promise((r) => setTimeout(r, wait)) : Promise.resolve();
+}


### PR DESCRIPTION
Proactive companion to the circuit breaker (#94): pace Spotify requests so we mostly stay **under** the rate limit instead of bursting into it.

### How
- `throttleSlot()` — a global "next slot" scheduler in `spotifyLimiter.js` that spaces consecutive Spotify requests **≥150 ms apart** (~6–7/sec), regardless of how many crate workers run concurrently.
- `spotifyRetry` awaits it before **every** request.

So the global request rate is capped proactively; the circuit breaker stays as the reactive backstop for any overshoot.

### Trade-off
Opening a big batch is **steadier but a bit slower** (paced, not bursted) — which is the point: far less likely to trip `429`s. Opening a few crates is unaffected (well under the cap).

### Testing notes
- Open a chunk of crates → requests should pace out (watch the Network tab — steady, not a wall of red 429s).
- The big "open all" will be slower but should ride under the limit instead of stampeding.
- `npm start` compiles (pre-existing `Playlist`/`Recommendations` warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)