### PR TITLE
perf: code-split heavy panels + drop underscore (native debounce)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -67,8 +67,6 @@ import FadeIn from 'react-fade-in';
 import changelog from './changelog.js';
 import CurrentSong from './components/CurrentSong/CurrentSong';
 import PLLibrary from './components/PLLibrary/PLLibrary';
-import SetBuilder from './components/PLLibrary/SetBuilder';
-import KeyCalculator from './utils/KeyCalculator';
 import SpotifyPlayer from 'react-spotify-web-playback';
 import SpotifyIcon from './components/SpotifyIcon';
 import { scWidgetSrc, scTrackUrl, loadScWidgetApi } from './utils/soundcloudCrates';
@@ -84,6 +82,12 @@ import {
   saveSoundcloudParams,
   clearSoundcloudParams,
 } from './utils/utils';
+
+// Code-split the two heavy, behind-a-click panels so they (and their unique
+// deps — e.g. the Camelot wheel) stay out of the initial bundle and only load
+// when the user actually opens the Set builder or Key calculator.
+const SetBuilder = React.lazy(() => import('./components/PLLibrary/SetBuilder'));
+const KeyCalculator = React.lazy(() => import('./utils/KeyCalculator'));
 
 const spotifyWebApi = new Spotify();
 
@@ -345,6 +349,10 @@ class App extends React.Component {
       // App-level set so it spans playlists. Entries are { item, key }.
       set: [],
       setOpen: false,
+      // Stays false until the set builder is first opened, so its lazy chunk
+      // isn't fetched until then. Once true it keeps SetBuilder mounted, so the
+      // dialog's open/close transitions still play.
+      setEverOpened: false,
       themeMode:
         window.localStorage.getItem(THEME_STORAGE_KEY) === 'dark'
           ? 'dark'
@@ -594,13 +602,13 @@ class App extends React.Component {
 
   openSet() {
     blurActive();
-    this.setState({ setOpen: true });
+    this.setState({ setOpen: true, setEverOpened: true });
   }
 
   // Replace the current set with a loaded saved set.
   loadSet(entries) {
     blurActive();
-    this.setState({ set: entries, setOpen: true });
+    this.setState({ set: entries, setOpen: true, setEverOpened: true });
   }
 
   // Open the library showing only hidden crates (reached from the menu).
@@ -1448,13 +1456,15 @@ class App extends React.Component {
           )}
 
           {this.state.showKeyCalculator && (
-            <KeyCalculator
-              open={this.state.showKeyCalculator}
-              onClose={this.openKeyCalculator}
-              bottomInset={
-                this.state.scNowPlaying ? 130 : loggedIn ? 96 : 0
-              }
-            />
+            <React.Suspense fallback={null}>
+              <KeyCalculator
+                open={this.state.showKeyCalculator}
+                onClose={this.openKeyCalculator}
+                bottomInset={
+                  this.state.scNowPlaying ? 130 : loggedIn ? 96 : 0
+                }
+              />
+            </React.Suspense>
           )}
 
           <Dialog
@@ -1527,19 +1537,25 @@ class App extends React.Component {
             </DialogActions>
           </Dialog>
 
-          {/* App-level set builder, reachable from any crate or the drawer */}
-          <SetBuilder
-            open={this.state.setOpen}
-            onClose={() => this.setState({ setOpen: false })}
-            set={this.state.set}
-            onReorder={this.reorderSet}
-            onRemove={this.removeFromSet}
-            onClear={this.clearSet}
-            userId={this.state.user_id}
-            onLoadSet={this.loadSet}
-            updatePlayer={this.updatePlayer}
-            onPlaySoundcloud={this.playSoundcloudTrack}
-          />
+          {/* App-level set builder, reachable from any crate or the drawer.
+              Not mounted until first opened (lazy chunk); stays mounted after
+              so its open/close animation still plays. */}
+          {this.state.setEverOpened && (
+            <React.Suspense fallback={null}>
+              <SetBuilder
+                open={this.state.setOpen}
+                onClose={() => this.setState({ setOpen: false })}
+                set={this.state.set}
+                onReorder={this.reorderSet}
+                onRemove={this.removeFromSet}
+                onClear={this.clearSet}
+                userId={this.state.user_id}
+                onLoadSet={this.loadSet}
+                updatePlayer={this.updatePlayer}
+                onPlaySoundcloud={this.playSoundcloudTrack}
+              />
+            </React.Suspense>
+          )}
 
           {/* The Spotify player stays mounted at all times — unmounting it
               tears down its Web Playback device ("Device not found"). While a

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from "react";
-import _ from "underscore";
+import { debounce } from "../../utils/debounce";
 
 import {
   Button,
@@ -685,7 +685,7 @@ let PLLibrary = (props) => {
     );
   }, [search, library]);
 
-  let handleChange = _.debounce((event) => {
+  let handleChange = debounce((event) => {
     event.persist();
     setSearch(String(event.target.value).toLowerCase());
   }, 500);

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import _ from "underscore";
+import { debounce } from "../../utils/debounce";
 
 import {
   makeStyles,
@@ -42,11 +42,14 @@ import { releaseSortKey, releaseYear } from "../../utils/release";
 import { useEffect } from "react";
 
 import Row from "./Row";
-import Recommendations from "./Recommendations";
 import KeyFilterPicker from "./KeyFilterPicker";
 import CrateDNA from "./CrateDNA";
 
 initializeApp(firebaseConfig);
+
+// Code-split: the owner-only Recommendations panel (and its deps) only loads
+// when an owned playlist is opened, keeping it out of the initial bundle.
+const Recommendations = React.lazy(() => import("./Recommendations"));
 
 const musicalKeys = [
   "C",
@@ -310,7 +313,7 @@ let Playlist = (props) => {
 
   let topRef = React.createRef();
 
-  let handleChange = _.debounce((event) => {
+  let handleChange = debounce((event) => {
     event.persist();
     setSearch(String(event.target.value).toLowerCase());
   }, 500);
@@ -501,9 +504,9 @@ let Playlist = (props) => {
       maxYear === "" &&
       energyFilter === "any"
     ) {
-      _.debounce(setSearchItems(allItems), 500);
+      debounce(setSearchItems(allItems), 500);
     } else {
-      _.debounce(
+      debounce(
         setSearchItems((searchItems) => {
           let filteredItems = allItems;
 
@@ -589,10 +592,10 @@ let Playlist = (props) => {
 
     let funcMap = {
       wheel: setWheel,
-      minBpm: _.debounce(setMinBpm, 500),
-      maxBpm: _.debounce(setMaxBpm, 500),
-      minYear: _.debounce(setMinYear, 500),
-      maxYear: _.debounce(setMaxYear, 500),
+      minBpm: debounce(setMinBpm, 500),
+      maxBpm: debounce(setMaxBpm, 500),
+      minYear: debounce(setMinYear, 500),
+      maxYear: debounce(setMaxYear, 500),
     };
 
     funcMap[type](setValue);
@@ -1126,16 +1129,18 @@ let Playlist = (props) => {
           )}
 
           {props.userId === props.playlistOwnerId && (
-            <Recommendations
-              token={props.token}
-              playlistId={props.playlistId}
-              playlistTracks={allItems}
-              playlistKeys={props.playlistKeys}
-              updatePlayer={props.updatePlayer}
-              addTracksToPlaylistState={props.addTracksToPlaylistState}
-              seedCamelot={harmonicAnchorCamelot}
-              seedBpm={anchorKey ? Math.round(anchorKey.bpm) : null}
-            />
+            <React.Suspense fallback={null}>
+              <Recommendations
+                token={props.token}
+                playlistId={props.playlistId}
+                playlistTracks={allItems}
+                playlistKeys={props.playlistKeys}
+                updatePlayer={props.updatePlayer}
+                addTracksToPlaylistState={props.addTracksToPlaylistState}
+                seedCamelot={harmonicAnchorCamelot}
+                seedBpm={anchorKey ? Math.round(anchorKey.bpm) : null}
+              />
+            </React.Suspense>
           )}
 
           <Fab

--- a/client/src/utils/debounce.js
+++ b/client/src/utils/debounce.js
@@ -1,0 +1,16 @@
+// Tiny native debounce — drop-in for the one underscore helper we used, so we
+// can drop the whole `underscore` dependency. Returns a function that delays
+// calling `fn` until `wait` ms have elapsed since the last call; `.cancel()`
+// clears a pending call.
+export function debounce(fn, wait) {
+  let timer;
+  function debounced(...args) {
+    const ctx = this;
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      if (typeof fn === "function") fn.apply(ctx, args);
+    }, wait);
+  }
+  debounced.cancel = () => clearTimeout(timer);
+  return debounced;
+}


### PR DESCRIPTION
**Speed-opt #4 — the last item of the end-of-project speed pass.**

Two bundle-shrinking changes:

### 1. Code-split behind-a-click panels (`React.lazy` + `Suspense`)
Each panel (and its unique deps) now downloads only when first used, instead of on app load:
- **Key calculator** (pulls in the Camelot wheel) — `App.js`
- **Set builder** — `App.js`; gated on a new `setEverOpened` flag so the lazy chunk waits for first open, then stays mounted afterward so the dialog's open/close transitions still animate
- **Recommendations** (owner-only panel) — `Playlist.jsx`

### 2. Dropped the `underscore` dependency
Its only use was `_.debounce`, replaced by a tiny native `debounce` util (`utils/debounce.js`) with the same API. No file imports `underscore` anymore, so it no longer ships in the bundle.

> Note: underscore's `package.json`/lockfile entry is now unused. I left it in deliberately — `client/package.json` already has an unrelated uncommitted `deploy` script edit, and I didn't want to fold that into this PR. Happy to prune it (`npm uninstall underscore`) on its own branch.

### Result
`main.js`: **~293 kB → 279.6 kB** gzipped. Deferred code moves to on-demand chunks (~10.9 / 3.8 / 3.2 / 1.2 kB). Build compiles cleanly (only the pre-existing `Playlist.jsx` / `Recommendations.jsx` / `utils.ts` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)