### PR TITLE
fix: lift Filter-by-key sheet above the bottom player

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1204,6 +1204,9 @@ class App extends React.Component {
                   onRefreshSoundcloud={this.refreshSoundcloudToken}
                   hideSets={this.state.disableScSets}
                   onPlaySoundcloud={this.playSoundcloudTrack}
+                  bottomInset={
+                    this.state.scNowPlaying ? 130 : this.state.spotify.loggedIn ? 96 : 0
+                  }
                 />
               </FadeIn>
             ) : (

--- a/client/src/components/PLLibrary/CombinedPlaylist.jsx
+++ b/client/src/components/PLLibrary/CombinedPlaylist.jsx
@@ -42,6 +42,7 @@ let CombinedPlaylist = (props) => {
     onAddToSet,
     onOpenSet,
     setCount,
+    bottomInset,
   } = props;
 
   // The app-level shared queue (so analysis continues after close + a global
@@ -191,6 +192,7 @@ let CombinedPlaylist = (props) => {
       setCount={setCount}
       combinedStatus={combinedStatus}
       scStatusById={scStatusById}
+      bottomInset={bottomInset}
     />
   );
 };

--- a/client/src/components/PLLibrary/KeyFilterPicker.jsx
+++ b/client/src/components/PLLibrary/KeyFilterPicker.jsx
@@ -39,6 +39,7 @@ const KeyFilterPicker = ({
   onClear,
   filterMode,
   onChangeFilterMode,
+  bottomInset = 0,
 }) => {
   let surface;
   if (filterMode === "combined") {
@@ -68,7 +69,11 @@ const KeyFilterPicker = ({
         style: {
           borderTopLeftRadius: 16,
           borderTopRightRadius: 16,
-          maxHeight: "88vh",
+          // Float the sheet above the fixed bottom player (Spotify ~96px /
+          // SoundCloud ~130px). The player has a higher z-index, so without
+          // this the wheel/piano gets painted over at the bottom.
+          bottom: bottomInset,
+          maxHeight: `calc(88vh - ${bottomInset}px)`,
         },
       }}
     >

--- a/client/src/components/PLLibrary/PLLibrary.jsx
+++ b/client/src/components/PLLibrary/PLLibrary.jsx
@@ -1973,6 +1973,7 @@ let PLLibrary = (props) => {
           onAddToSet={props.onAddToSet}
           onOpenSet={props.onOpenSet}
           setCount={props.setCount}
+          bottomInset={props.bottomInset}
         />
       ) : null}
 
@@ -1994,6 +1995,7 @@ let PLLibrary = (props) => {
         onAddToSet={props.onAddToSet}
         onOpenSet={props.onOpenSet}
         setCount={props.setCount}
+        bottomInset={props.bottomInset}
       />
     </>
   );

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -1164,6 +1164,7 @@ let Playlist = (props) => {
           onClear={() => setKeyFilter([])}
           filterMode={filterMode}
           onChangeFilterMode={changeFilterMode}
+          bottomInset={props.bottomInset}
         />
 
       </Dialog>


### PR DESCRIPTION
**Bug:** When filtering by key (wheel or piano), the bottom of the picker — including the Camelot wheel — was hidden behind the fixed SoundCloud/Spotify player bar.

**Cause:** The "Filter by key" picker is a bottom-anchored MUI `Drawer` pinned to the viewport bottom (`maxHeight: 88vh`). The bottom player is `position: fixed` with a higher z-index (9999/10000), so it paints over the lower portion of the sheet.

**Fix:** Reuse the exact `bottomInset` the Key Calculator already uses — `scNowPlaying ? 130 : loggedIn ? 96 : 0` — threaded `App → PLLibrary → Playlist / CombinedPlaylist → KeyFilterPicker`. On the Drawer `Paper` set `bottom: inset` + `maxHeight: calc(88vh - inset)`, so the whole sheet floats just above the player and the wheel/piano render fully. When no player is present (`inset = 0`), behavior is unchanged.

Covers both the Spotify single/Open(N) view and the SoundCloud/combined view (both route through `Playlist`). Build compiles (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)