### PR TITLE
feat: madmom band-constrained BPM (fixes the ¾-tempo errors)

### DIFF
--- a/analysis-service/Dockerfile
+++ b/analysis-service/Dockerfile
@@ -1,15 +1,17 @@
 # KeyTrack analysis microservice.
-# Bundles the native audio tools the analysis needs (ffmpeg + bpm-tools, plus
-# libKeyFinder/keyfinder-cli built from source) — none of which install cleanly
-# on Heroku buildpacks, which is exactly why this is its own container.
+# Bundles the native audio tools the analysis needs (ffmpeg, libKeyFinder/
+# keyfinder-cli built from source, and madmom for tempo) — none of which install
+# cleanly on Heroku buildpacks, which is exactly why this is its own container.
 FROM node:20-bookworm-slim
 
-# Runtime tools (ffmpeg, bpm-tools) + build deps for libKeyFinder & keyfinder-cli.
+# Runtime tools (ffmpeg) + build deps for libKeyFinder & keyfinder-cli + Python
+# (for the madmom tempo venv).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ffmpeg bpm-tools \
+      ffmpeg \
       git cmake build-essential ca-certificates \
       libfftw3-dev \
       libavcodec-dev libavformat-dev libavutil-dev libswresample-dev \
+      python3 python3-venv python3-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # libKeyFinder (GPL-3.0) — the key-detection library the Mixxx DJ app maintains.
@@ -26,6 +28,15 @@ RUN git clone --depth 1 https://github.com/evanpurkhiser/keyfinder-cli.git /tmp/
  && c++ -std=c++17 /tmp/kfc/keyfinder_cli.cpp -o /usr/local/bin/keyfinder-cli \
       -lkeyfinder -lavcodec -lavformat -lavutil -lswresample \
  && rm -rf /tmp/kfc
+
+# madmom (BSD/academic) in its own venv → band-constrained tempo (bpm_madmom.py).
+# Pinned numpy<2 (madmom needs it); built from git master for current
+# Python/numpy compatibility. Its model files ship inside the package.
+RUN python3 -m venv /opt/madmom-venv \
+ && /opt/madmom-venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel \
+ && /opt/madmom-venv/bin/pip install --no-cache-dir "numpy<2" cython scipy mido \
+ && /opt/madmom-venv/bin/pip install --no-cache-dir --no-build-isolation \
+      "git+https://github.com/CPJKU/madmom.git"
 
 WORKDIR /app
 COPY package*.json ./

--- a/analysis-service/analyze.js
+++ b/analysis-service/analyze.js
@@ -1,8 +1,10 @@
-// The analysis pipeline: audio → key (keyfinder-cli) + BPM (bpm-tools).
+// The analysis pipeline: audio → key (keyfinder-cli) + BPM (madmom).
 //
-// We shell out to two GPL command-line tools as separate processes (no linking
-// into our code), so this service — and KeyTrack — stay MIT.
-const { execFile, spawn } = require("child_process");
+// Key detection shells out to keyfinder-cli (GPL) as a separate process (no
+// linking), so this service — and KeyTrack — stay MIT. BPM is computed by
+// madmom (band-constrained, genre-aware) via a separate Python venv; see
+// bpm_madmom.py.
+const { execFile } = require("child_process");
 const { promisify } = require("util");
 const fs = require("fs");
 const os = require("os");
@@ -10,7 +12,6 @@ const path = require("path");
 const execFileP = promisify(execFile);
 
 const { CAMELOT_TO_KEY } = require("./camelot");
-const { octaveFold } = require("./bpm");
 
 // Tracks longer than this are almost certainly DJ sets/mixes — their key/BPM
 // wander, so analysis is meaningless. Mirror the frontend constant.
@@ -18,8 +19,10 @@ const LIKELY_SET_MS = 6 * 60 * 1000;
 // Allow overriding the binary paths for local dev (where keyfinder-cli may be
 // a freshly-built binary rather than on PATH).
 const KEYFINDER = process.env.KEYFINDER_CLI || "keyfinder-cli";
-const BPM_BIN = process.env.BPM_BIN || "bpm";
 const FFMPEG = process.env.FFMPEG || "ffmpeg";
+// BPM is computed by madmom in its own Python venv (overridable for local dev).
+const MADMOM_PY = process.env.MADMOM_PY || "/opt/madmom-venv/bin/python";
+const MADMOM_BPM = path.join(__dirname, "bpm_madmom.py");
 
 const run = (cmd, args) =>
   execFileP(cmd, args, { maxBuffer: 1 << 26 }).then((r) => r.stdout.trim());
@@ -64,21 +67,16 @@ async function detectKey(wav) {
   return { camelot: camelot || null, key: (camelot && CAMELOT_TO_KEY[camelot]) || null };
 }
 
-// bpm-tools reads raw float samples from stdin — pipe ffmpeg's PCM into it.
+// BPM via madmom: shell out to the Python script (like keyfinder-cli) with the
+// decoded segment + SoundCloud genre tag. It prints a single integer BPM
+// already folded into the genre's tempo band, or nothing on failure → null.
 function detectBpm(seg, genre) {
-  return new Promise((resolve) => {
-    const ff = spawn(FFMPEG, ["-v", "quiet", "-i", seg, "-f", "f32le", "-ar", "44100", "-ac", "1", "-"]);
-    const bpm = spawn(BPM_BIN, ["-m", "70", "-x", "180"]);
-    let out = "";
-    ff.stdout.pipe(bpm.stdin);
-    bpm.stdout.on("data", (d) => (out += d));
-    ff.on("error", () => {});
-    bpm.on("error", () => resolve(null));
-    bpm.on("close", () => {
-      const raw = parseFloat(out);
-      resolve(raw ? octaveFold(raw, genre) : null);
-    });
-  });
+  return run(MADMOM_PY, [MADMOM_BPM, seg, genre || ""])
+    .then((out) => {
+      const v = parseInt(out, 10);
+      return Number.isFinite(v) && v > 0 ? v : null;
+    })
+    .catch(() => null);
 }
 
 // Analyze a local file path OR a remote URL. `headers` is passed to ffmpeg for

--- a/analysis-service/bpm_madmom.py
+++ b/analysis-service/bpm_madmom.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Band-constrained, genre-aware tempo detection via madmom's RNN beat tracker.
+#
+#   Usage:  bpm_madmom.py <audio.(wav|...)> [genre]
+#   Output: a single integer BPM on stdout (nothing at all on failure).
+#
+# Why this exists: bpm-tools (our old detector) reliably finds the *period* but
+# often emits a metric subharmonic — and crucially can emit ¾-of-tempo values
+# (e.g. 124 for a 165 track) that land *inside* any sane range, so no octave
+# fold can rescue them. madmom's tempo candidates are clean octave multiples of
+# the truth, so constraining its search to the genre's tempo band reliably
+# recovers the right one. DJ material clusters in 110–180; hip-hop and
+# downtempo get their own bands. Genuinely-sub-110 tracks tagged as generic
+# "electronic" will be pushed up — those are corrected with the per-track
+# manual override on the client.
+import sys
+
+
+def band_for(genre):
+    g = (genre or "").lower()
+    if any(k in g for k in ("hip hop", "hip-hop", "rap", "r&b", "rnb", "boom bap")):
+        return 80, 115
+    if any(k in g for k in ("downtempo", "down-tempo", "midtempo", "mid-tempo",
+                            "chill", "lo-fi", "lofi", "ambient")):
+        return 85, 110
+    # Default: electronic (house/techno/dnb/dubstep/trap/future bass/…).
+    return 110, 180
+
+
+def main():
+    if len(sys.argv) < 2:
+        return
+    wav = sys.argv[1]
+    genre = sys.argv[2] if len(sys.argv) > 2 else ""
+    lo, hi = band_for(genre)
+    try:
+        from madmom.features.beats import RNNBeatProcessor
+        from madmom.features.tempo import TempoEstimationProcessor
+        act = RNNBeatProcessor()(wav)
+        tempi = TempoEstimationProcessor(min_bpm=lo, max_bpm=hi, fps=100)(act)
+        if len(tempi):
+            print(int(round(float(tempi[0][0]))))
+    except Exception:
+        # Stay silent: the Node caller treats no/garbage output as "no BPM"
+        # (null) rather than a wrong number.
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/client/src/utils/scAnalysis.js
+++ b/client/src/utils/scAnalysis.js
@@ -18,7 +18,9 @@ import {
 //
 // Bump ENGINE_VERSION to invalidate every cached analysis if the engine
 // changes (so old/worse results get recomputed).
-const ENGINE_VERSION = 1;
+//   v2: BPM detection moved from bpm-tools to madmom (band-constrained,
+//       genre-aware) — far better tempo octave resolution, so re-analyze.
+const ENGINE_VERSION = 2;
 
 // Firestore doc ids can't contain "/" — urns look like "soundcloud:tracks:123".
 const keyId = (urn) => String(urn).replace(/[:/]/g, "_");


### PR DESCRIPTION
Replaces `bpm-tools` with **madmom** (band-constrained, genre-aware) for SoundCloud BPM detection.

### Why
`bpm-tools` found the period but emitted metric subharmonics — including **¾-of-tempo** values that land *inside* any sane range, so `octaveFold` (octave-only) couldn't fix them. Benchmarked on **THIS IS MYNN** + 2 standalone tracks:

| Track | True | Old (bpm-tools) | madmom + band |
|---|---|---|---|
| For The Best | 165 | 124 ❌ | **167** ✅ |
| Alaska (standalone) | 150 | 113 ❌ | **150** ✅ |
| Someone Like U | 150 | 114 ❌ | **150** ✅ |

madmom's tempo candidates are **clean octave multiples** of the truth (75 & 150, 82 & 164), so constraining the search to the genre's band reliably recovers the right one.

### What
- **`bpm_madmom.py`** — madmom RNN beat tracker + band-constrained `TempoEstimationProcessor`. Genre→band: hip-hop `80–115`, downtempo/midtempo `85–110`, else (electronic/DnB/…) `110–180`.
- **`analyze.js`** — `detectBpm` shells out to it (same pattern as keyfinder-cli) with the decoded segment + SoundCloud genre tag. Drops bpm-tools + octaveFold.
- **`Dockerfile`** — adds `python3` + a madmom venv (numpy<2, git master); drops the unused `bpm-tools` package.
- **`scAnalysis.js`** — `ENGINE_VERSION` 1→2 so cached BPMs recompute.

### Trade-off
A genuinely **sub-110** track tagged generically (e.g. a true-90 remix tagged "Dance & EDM") gets pushed up by the band → that's the **per-track manual override** case (fast-follow PR). Tagging it "midtempo" keeps it at 90 (verified).

### ⚠️ Deploy order (matters for quota)
1. **Deploy analysis-service first** (subtree-split → `heroku-analysis`) so the new engine is live.
2. *Then* run/deploy the frontend (`ENGINE_VERSION=2`) — it invalidates the cache and re-analyzes on crate open. Doing it in the other order would re-spend stream quota on the *old* engine.

Key detection (keyfinder-cli) is unchanged. Per-track latency rises (~+3–6s/track for madmom's NN) — acceptable for a one-time recompute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)