### PR TITLE
feat: per-track manual BPM override (SoundCloud rows)

### DIFF
--- a/client/src/components/PLLibrary/BpmOverride.jsx
+++ b/client/src/components/PLLibrary/BpmOverride.jsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { Popover, Box, Chip, Typography, Input, Button } from "@material-ui/core";
+
+// The metric relatives a tempo detector typically confuses. Showing the
+// detected value's whole family as one-tap chips means the right answer (often
+// a ½/⅔/¾/1⅓/2× of what was detected) is a single click — no math for the user.
+const FACTORS = [0.5, 2 / 3, 0.75, 1, 4 / 3, 1.5, 2];
+
+// A clickable BPM value (SoundCloud rows): tap it to correct a mis-detected
+// tempo. The correction is saved to the shared analysis cache so it sticks.
+export default function BpmOverride({ bpm, onSet }) {
+  const [anchor, setAnchor] = React.useState(null);
+  const [manual, setManual] = React.useState("");
+  const rounded = Math.round(bpm);
+
+  const candidates = React.useMemo(() => {
+    const s = new Set(
+      FACTORS.map((f) => Math.round(bpm * f)).filter((v) => v >= 40 && v <= 300)
+    );
+    return [...s].sort((a, b) => a - b);
+  }, [bpm]);
+
+  const close = () => {
+    setAnchor(null);
+    setManual("");
+  };
+  const choose = (v) => {
+    onSet(v);
+    close();
+  };
+
+  return (
+    <>
+      <span
+        onClick={(e) => {
+          e.stopPropagation();
+          setAnchor(e.currentTarget);
+        }}
+        title="Click to correct the BPM"
+        style={{ cursor: "pointer", borderBottom: "1px dotted #999" }}
+      >
+        {rounded}
+      </span>
+      <Popover
+        open={Boolean(anchor)}
+        anchorEl={anchor}
+        onClose={close}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        transformOrigin={{ vertical: "top", horizontal: "center" }}
+        disableScrollLock
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Box style={{ padding: 12, maxWidth: 260 }}>
+          <Typography variant="caption" color="textSecondary">
+            Correct BPM — tap a multiple or type the exact value
+          </Typography>
+          <Box style={{ display: "flex", flexWrap: "wrap", gap: 6, margin: "8px 0" }}>
+            {candidates.map((v) => (
+              <Chip
+                key={v}
+                size="small"
+                label={v}
+                clickable
+                color={v === rounded ? "primary" : "default"}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  choose(v);
+                }}
+              />
+            ))}
+          </Box>
+          <Box style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <Input
+              type="number"
+              placeholder="exact"
+              value={manual}
+              onChange={(e) => setManual(e.target.value)}
+              onClick={(e) => e.stopPropagation()}
+              style={{ width: 64 }}
+            />
+            <Button
+              size="small"
+              disabled={!manual || parseInt(manual, 10) <= 0}
+              onClick={(e) => {
+                e.stopPropagation();
+                const v = parseInt(manual, 10);
+                if (v > 0) choose(v);
+              }}
+            >
+              Set
+            </Button>
+            <Button
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation();
+                onSet(null);
+                close();
+              }}
+              style={{ marginLeft: "auto", textTransform: "none" }}
+              title="Revert to the auto-detected BPM"
+            >
+              Auto
+            </Button>
+          </Box>
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/client/src/components/PLLibrary/CombinedPlaylist.jsx
+++ b/client/src/components/PLLibrary/CombinedPlaylist.jsx
@@ -47,7 +47,14 @@ let CombinedPlaylist = (props) => {
 
   // The app-level shared queue (so analysis continues after close + a global
   // indicator shows progress).
-  const { analysis, enqueueAll } = useScAnalysis();
+  const { analysis, enqueueAll, setBpmOverride } = useScAnalysis();
+
+  // Manual BPM correction for a SoundCloud row (track.id === urn here). Stable
+  // identity so memoized Rows don't churn.
+  const onOverrideBpm = React.useCallback(
+    (urn, bpm) => setBpmOverride(urn, bpm),
+    [setBpmOverride]
+  );
 
   // Auto-analyze the SoundCloud tracks on open so their key/BPM fill in live.
   React.useEffect(() => {
@@ -94,7 +101,9 @@ let CombinedPlaylist = (props) => {
         if (!a || !a.camelot) return null;
         const km = camelotToKeyMode(a.camelot);
         if (!km) return null;
-        return { id: urn, key: km.key, mode: km.mode, tempo: a.bpm, energy: null };
+        // A manual BPM correction (bpmOverride) wins over our detected bpm.
+        const tempo = a.bpmOverride != null ? a.bpmOverride : a.bpm;
+        return { id: urn, key: km.key, mode: km.mode, tempo, energy: null };
       })
       .filter(Boolean);
     return [...(spotifyFeatures || []), ...scKeys];
@@ -193,6 +202,7 @@ let CombinedPlaylist = (props) => {
       combinedStatus={combinedStatus}
       scStatusById={scStatusById}
       bottomInset={bottomInset}
+      onOverrideBpm={onOverrideBpm}
     />
   );
 };

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -1081,6 +1081,7 @@ let Playlist = (props) => {
                     harmonicAnchorCamelot={harmonicAnchorCamelot}
                     onToggleAnchor={toggleHarmonicAnchor}
                     onAddToSet={handleAddToSet}
+                    onOverrideBpm={props.onOverrideBpm}
                     scStatus={
                       props.scStatusById
                         ? props.scStatusById[item.track.id]

--- a/client/src/components/PLLibrary/Row.jsx
+++ b/client/src/components/PLLibrary/Row.jsx
@@ -12,6 +12,7 @@ import KeyMap from "../../utils/KeyMap";
 import { camelotColor, harmonicRelation } from "../../utils/harmonic";
 import { formatReleaseDate } from "../../utils/release";
 import { SpotifyIcon, SoundcloudIcon } from "../BrandIcons";
+import BpmOverride from "./BpmOverride";
 
 let Row = (props) => {
   const { item } = props;
@@ -303,7 +304,20 @@ let Row = (props) => {
           {trackKey ? (trackKey.mode === 1 ? "Major" : "Minor") : "N/A"}
         </TableCell>
       )}
-      <TableCell>{trackKey ? Math.round(trackKey.bpm) : "N/A"}</TableCell>
+      <TableCell>
+        {trackKey ? (
+          isSoundcloud && props.onOverrideBpm && Number.isFinite(trackKey.bpm) ? (
+            <BpmOverride
+              bpm={trackKey.bpm}
+              onSet={(v) => props.onOverrideBpm(item.track.id, v)}
+            />
+          ) : (
+            Math.round(trackKey.bpm)
+          )
+        ) : (
+          "N/A"
+        )}
+      </TableCell>
       {!props.isTablet && (
         <TableCell style={{ whiteSpace: "nowrap" }}>
           {formatReleaseDate(item.track)}

--- a/client/src/components/SoundCloud/ScAnalysis.jsx
+++ b/client/src/components/SoundCloud/ScAnalysis.jsx
@@ -40,14 +40,14 @@ export function ScAnalysisProvider({
     [connected, token, backend, onRefreshToken]
   );
 
-  const { analysis, enqueue, enqueueAll, meta, progress } =
+  const { analysis, enqueue, enqueueAll, setBpmOverride, meta, progress } =
     useScAnalysisQueue(scFetch);
 
   // Only the enqueue API + analysis map go through context; identities are
   // stable, so consumers only re-render when `analysis` actually changes.
   const value = React.useMemo(
-    () => ({ analysis, enqueue, enqueueAll }),
-    [analysis, enqueue, enqueueAll]
+    () => ({ analysis, enqueue, enqueueAll, setBpmOverride }),
+    [analysis, enqueue, enqueueAll, setBpmOverride]
   );
 
   return (

--- a/client/src/components/SoundCloud/useScAnalysisQueue.js
+++ b/client/src/components/SoundCloud/useScAnalysisQueue.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { getScAnalysis, getScAnalysisBulk, saveScAnalysis } from "../../utils/scAnalysis";
+import { getScAnalysis, getScAnalysisBulk, saveScAnalysis, saveScBpmOverride } from "../../utils/scAnalysis";
 import { isLikelySet } from "../../utils/soundcloudCrates";
 
 // A single-worker FIFO queue that lazily computes our key/BPM for SoundCloud
@@ -154,5 +154,19 @@ export function useScAnalysisQueue(scFetch) {
     [processQueue]
   );
 
-  return { analysis, enqueue, enqueueAll, meta: metaRef.current, progress };
+  // Apply a user's manual BPM correction: update the live map (so the row
+  // re-renders immediately) and persist it to the shared cache. null clears it.
+  const setBpmOverride = React.useCallback((urn, bpm) => {
+    setAnalysis((a) => {
+      const cur = a[urn];
+      if (!cur) return a;
+      return {
+        ...a,
+        [urn]: { ...cur, bpmOverride: bpm == null ? null : Math.round(bpm) },
+      };
+    });
+    saveScBpmOverride(urn, bpm);
+  }, []);
+
+  return { analysis, enqueue, enqueueAll, setBpmOverride, meta: metaRef.current, progress };
 }

--- a/client/src/utils/scAnalysis.js
+++ b/client/src/utils/scAnalysis.js
@@ -84,3 +84,18 @@ export async function saveScAnalysis(urn, data) {
     console.error("saveScAnalysis failed", e);
   }
 }
+
+// Persist a user's manual BPM correction onto the cached analysis doc (pass
+// null to clear it). Merges so it never clobbers the rest of the analysis, and
+// because it's on the shared doc the correction sticks for every view + session.
+export async function saveScBpmOverride(urn, bpm) {
+  try {
+    await setDoc(
+      doc(getFirestore(), "scAnalysis", keyId(urn)),
+      { bpmOverride: bpm == null ? null : Math.round(bpm), urn },
+      { merge: true }
+    );
+  } catch (e) {
+    console.error("saveScBpmOverride failed", e);
+  }
+}


### PR DESCRIPTION
Fast-follow to **#98** (madmom BPM). For the handful of tracks *any* detector gets wrong — e.g. a genuine sub-110 track tagged generically "Dance & EDM" that the band-constraint pushes up — let the user correct the BPM by hand.

### UX
Click a SoundCloud row's **BPM** → a small popover with:
- The detected value's **metric family** as one-tap chips: ½ · ⅔ · ¾ · 1 · 1⅓ · 1½ · 2× (e.g. `124` → `62 · 83 · 93 · 124 · 165 · 186 · 248`, so the right tempo is usually one tap),
- an **exact** number entry, and
- an **Auto** button to revert to the detected value.

The correction saves to the shared `scAnalysis` doc (merge) so it **persists across views and sessions** for everyone, and updates the live analysis map so the row re-renders immediately.

### Files
- `BpmOverride.jsx` — the clickable value + popover (new).
- `scAnalysis.js` — `saveScBpmOverride` (merge; `null` clears).
- `useScAnalysisQueue` / `ScAnalysis` context — `setBpmOverride(urn, bpm)` (stable identity, so memoized Rows don't churn).
- `CombinedPlaylist` — `bpmOverride` wins in `playlistKeys`; passes the callback down.
- `Playlist` / `Row` — SoundCloud rows render the editable BPM; **Spotify rows are untouched** (their BPM is authoritative).

Builds clean (pre-existing warnings only). Pairs with #98 — together they make BPM reliable: madmom fixes the common octave errors automatically, this catches the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)