### PR TITLE
fix: Back-to-Top clears the player + remove page overscroll bounce

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,3 +1,10 @@
+html,
+body {
+  /* Disable the elastic "rubber-band" overscroll at the page edges — that
+     pull-away past the top/bottom/sides reads as unintentional. */
+  overscroll-behavior: none;
+}
+
 .App {
   text-align: center;
   padding-bottom: 120px; /* Space for fixed player at bottom */

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -943,7 +943,10 @@ let Playlist = (props) => {
         </AppBar>
 
         <div style={{
-          paddingBottom: isMobile ? "180px" : "63px",
+          // Clear the fixed bottom player (its MEASURED height) so the
+          // full-width "Back To Top" bar at the end of the list is never hidden
+          // behind it — for either player, any height.
+          paddingBottom: `${(props.bottomInset || 0) + (isMobile ? 40 : 24)}px`,
           overflowX: isMobile ? "auto" : "visible",
           overflowY: "visible"
         }}>


### PR DESCRIPTION
Two small UI fixes.

### 1. "Back To Top" hidden behind the player
The full-width Back-to-Top bar at the end of a crate was covered by the bottom player — the old list padding was a fixed `63px`, but the players are taller (SoundCloud is 120px). Now the list's bottom padding uses the **measured** player height (`props.bottomInset`, from #100) + a small buffer, so the bar always sits above whichever player is showing, any height.

### 2. Page edge "rubber-band" overscroll
Scrolling past the top/bottom/sides let the page elastically pull away from the edge, which reads as unintentional. Added `overscroll-behavior: none` on `html, body` to disable it (also stops scroll-chaining into the page behind modals).

Builds clean (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)