### PR TITLE
feat: chord-loop detection for SoundCloud tracks

### DIFF
--- a/analysis-service/analyze.js
+++ b/analysis-service/analyze.js
@@ -20,9 +20,11 @@ const LIKELY_SET_MS = 6 * 60 * 1000;
 // a freshly-built binary rather than on PATH).
 const KEYFINDER = process.env.KEYFINDER_CLI || "keyfinder-cli";
 const FFMPEG = process.env.FFMPEG || "ffmpeg";
-// BPM is computed by madmom in its own Python venv (overridable for local dev).
+// BPM + chords are computed by madmom in its own Python venv (overridable for
+// local dev).
 const MADMOM_PY = process.env.MADMOM_PY || "/opt/madmom-venv/bin/python";
 const MADMOM_BPM = path.join(__dirname, "bpm_madmom.py");
+const MADMOM_CHORDS = path.join(__dirname, "chords_madmom.py");
 
 const run = (cmd, args) =>
   execFileP(cmd, args, { maxBuffer: 1 << 26 }).then((r) => r.stdout.trim());
@@ -79,6 +81,22 @@ function detectBpm(seg, genre) {
     .catch(() => null);
 }
 
+// Chord loop via madmom: prints a JSON array of the repeating chords in cyclic
+// order (rotated to the camelot tonic + spelled to its key), or `null` when
+// there's no clear loop. `camelot` is our own keyfinder result.
+function detectChords(seg, camelot) {
+  return run(MADMOM_PY, [MADMOM_CHORDS, seg, camelot || ""])
+    .then((out) => {
+      try {
+        const arr = JSON.parse(out);
+        return Array.isArray(arr) && arr.length ? arr : null;
+      } catch (e) {
+        return null;
+      }
+    })
+    .catch(() => null);
+}
+
 // Analyze a local file path OR a remote URL. `headers` is passed to ffmpeg for
 // remote (HLS) inputs so it can fetch the playlist + segments with auth.
 async function analyzeFile(input, { durationMs, genre, headers } = {}) {
@@ -86,8 +104,14 @@ async function analyzeFile(input, { durationMs, genre, headers } = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kt-an-"));
   try {
     const { wav, seg } = await decode(input, durationMs, dir, headers);
-    const [key, bpm] = await Promise.all([detectKey(wav), detectBpm(seg, genre)]);
-    return { isLikelySet: false, camelot: key.camelot, key: key.key, bpm };
+    // key + BPM run in parallel; chords need the detected key for their
+    // starting rotation, so they kick off once key resolves and then run
+    // alongside BPM.
+    const keyP = detectKey(wav);
+    const bpmP = detectBpm(seg, genre);
+    const key = await keyP;
+    const [bpm, chords] = await Promise.all([bpmP, detectChords(seg, key.camelot)]);
+    return { isLikelySet: false, camelot: key.camelot, key: key.key, bpm, chords };
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/analysis-service/chords_madmom.py
+++ b/analysis-service/chords_madmom.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Repeating chord-loop detection for SoundCloud tracks, via madmom (CNN chord
+# features + CRF recognition — the same library we already bundle for BPM).
+#
+#   Usage:  chords_madmom.py <audio.wav> [camelot]
+#   Output: a JSON array of the loop's chords in cyclic order, spelled to the
+#           track's key and rotated to start on the tonic, e.g.
+#               ["Db","Ab","Eb","Bbm"]
+#           or the literal `null` when there's no clear repeating loop
+#           (busy / percussive / tooly tracks).
+#
+# We detect the *loop* (the N chords, in order), not a timeline: collapse
+# madmom's chord timeline, keep the core chords covering ~85% of the time, then
+# reconstruct the cyclic order from the most-common chord-to-chord transitions
+# (robust to a stray passing chord). The optional camelot (our keyfinder result)
+# only picks the starting rotation + flat/sharp spelling — the cycle itself is
+# key-independent.
+import sys, json
+from collections import Counter
+
+SHARP = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B']
+FLAT  = ['C','Db','D','Eb','E','F','Gb','G','Ab','A','Bb','B']
+# camelot -> (tonic pitch-class, mode, use_flats)
+CAM = {
+ '8B':(0,'maj',False),'9B':(7,'maj',False),'10B':(2,'maj',False),'11B':(9,'maj',False),
+ '12B':(4,'maj',False),'1B':(11,'maj',False),'2B':(6,'maj',False),'3B':(1,'maj',True),
+ '4B':(8,'maj',True),'5B':(3,'maj',True),'6B':(10,'maj',True),'7B':(5,'maj',True),
+ '8A':(9,'min',False),'9A':(4,'min',False),'10A':(11,'min',False),'11A':(6,'min',False),
+ '12A':(1,'min',False),'1A':(8,'min',False),'2A':(3,'min',True),'3A':(10,'min',True),
+ '4A':(5,'min',True),'5A':(0,'min',True),'6A':(7,'min',True),'7A':(2,'min',True),
+}
+
+def parse(label):  # "C#:maj" -> (pitch-class, is_minor)
+    n, q = label.split(':')
+    pc = SHARP.index(n) if n in SHARP else (FLAT.index(n) if n in FLAT else None)
+    return pc, (q == 'min')
+
+def name(pc, is_min, use_flats):
+    return (FLAT if use_flats else SHARP)[pc] + ('m' if is_min else '')
+
+def collapse(segs, min_dur=0.8):
+    seq = []
+    for s, e, l in segs:
+        if l == 'N' or (e - s) < min_dur:
+            continue
+        if not seq or seq[-1] != l:
+            seq.append(l)
+    return seq
+
+def dedup(s):
+    out = []
+    for c in s:
+        if not out or out[-1] != c:
+            out.append(c)
+    return out
+
+def core_chords(seq, cover=0.85, cap=6):
+    cnt = Counter(seq); total = len(seq); cum = 0; core = []
+    for c, n in cnt.most_common():
+        core.append(c); cum += n
+        if cum / total >= cover or len(core) >= cap:
+            break
+    return core, sum(cnt[c] for c in core) / total
+
+def loop_order(seq, core):
+    cs = set(core); sf = dedup([c for c in seq if c in cs])
+    trans = Counter(zip(sf, sf[1:]))
+    start = Counter(sf).most_common(1)[0][0]; cyc = [start]; cur = start
+    while len(cyc) < len(cs):
+        cand = [(nx, n) for (a, nx), n in trans.items() if a == cur and nx not in cyc]
+        if not cand:
+            break
+        cur = max(cand, key=lambda x: x[1])[0]; cyc.append(cur)
+    return cyc
+
+def rotate(cyc, tonic, mode):
+    want = (mode == 'min')
+    for i, l in enumerate(cyc):
+        pc, m = parse(l)
+        if pc == tonic and m == want:
+            return cyc[i:] + cyc[:i]
+    for i, l in enumerate(cyc):
+        pc, _ = parse(l)
+        if pc == tonic:
+            return cyc[i:] + cyc[:i]
+    return cyc
+
+def main():
+    if len(sys.argv) < 2:
+        print("null"); return
+    wav = sys.argv[1]
+    info = CAM.get(sys.argv[2] if len(sys.argv) > 2 else "")
+    use_flats = info[2] if info else False
+    try:
+        from madmom.features.chords import CNNChordFeatureProcessor, CRFChordRecognitionProcessor
+        raw = CRFChordRecognitionProcessor()(CNNChordFeatureProcessor()(wav))
+        segs = [(float(s), float(e), (l.decode() if isinstance(l, bytes) else str(l)))
+                for s, e, l in raw]
+    except Exception:
+        print("null"); return
+    seq = collapse(segs)
+    if not seq:
+        print("null"); return
+    core, cov = core_chords(seq)
+    if len(core) > 5 or cov < 0.6:   # busy / no clear loop
+        print("null"); return
+    cyc = loop_order(seq, core)
+    if info:
+        cyc = rotate(cyc, info[0], info[1])
+    print(json.dumps([name(*parse(l), use_flats) for l in cyc]))
+
+main()

--- a/client/src/components/CurrentSong/CurrentSong.jsx
+++ b/client/src/components/CurrentSong/CurrentSong.jsx
@@ -43,7 +43,11 @@ let CurrentSong = (props) => {
     const urn = props.scTrack.urn || String(props.scTrack.id);
     getScAnalysis(urn).then((a) => {
       if (cancelled) return;
-      setSc(a && a.camelot ? { camelot: a.camelot, bpm: a.bpm } : { camelot: null });
+      setSc(
+        a && a.camelot
+          ? { camelot: a.camelot, bpm: a.bpm, chords: a.chords }
+          : { camelot: null }
+      );
     });
     return () => {
       cancelled = true;
@@ -232,20 +236,34 @@ let CurrentSong = (props) => {
         </Box>
 
         {cam ? (
-          <Box style={{ display: "flex", gap: 6, marginTop: 10, flexWrap: "wrap" }}>
-            {info && (
+          <>
+            <Box style={{ display: "flex", gap: 6, marginTop: 10, flexWrap: "wrap" }}>
+              {info && (
+                <Chip
+                  size="small"
+                  label={`${info.musical} ${info.quality === "Major" ? "Maj" : "Min"}`}
+                />
+              )}
               <Chip
                 size="small"
-                label={`${info.musical} ${info.quality === "Major" ? "Maj" : "Min"}`}
+                label={cam}
+                style={scColor ? { backgroundColor: scColor.bg, color: scColor.text } : {}}
               />
+              {sc.bpm && <Chip size="small" label={`${Math.round(sc.bpm)} BPM`} />}
+            </Box>
+            {sc.chords && sc.chords.length > 0 && (
+              <Typography
+                variant="caption"
+                color="textSecondary"
+                style={{ display: "block", marginTop: 6 }}
+              >
+                Chords (est.):{" "}
+                <span style={{ fontWeight: 600, color: "rgba(0,0,0,0.72)" }}>
+                  {sc.chords.join(" → ")}
+                </span>
+              </Typography>
             )}
-            <Chip
-              size="small"
-              label={cam}
-              style={scColor ? { backgroundColor: scColor.bg, color: scColor.text } : {}}
-            />
-            {sc.bpm && <Chip size="small" label={`${Math.round(sc.bpm)} BPM`} />}
-          </Box>
+          </>
         ) : (
           <Typography
             variant="caption"

--- a/client/src/components/PLLibrary/CombinedPlaylist.jsx
+++ b/client/src/components/PLLibrary/CombinedPlaylist.jsx
@@ -177,6 +177,17 @@ let CombinedPlaylist = (props) => {
     return m;
   }, [scTracks, analysis]);
 
+  // Per-row chord loop (urn -> ["Db","Ab","Eb","Bbm"]) for the Key-cell reveal.
+  const chordsById = React.useMemo(() => {
+    const m = {};
+    (scTracks || []).forEach((t) => {
+      const urn = t.urn || String(t.id);
+      const a = analysis[urn];
+      if (a && a.chords && a.chords.length) m[urn] = a.chords;
+    });
+    return m;
+  }, [scTracks, analysis]);
+
   // Mount the Playlist only while open, so it initializes its internal
   // searchItems from the FULL track list (the data is ready by the time `open`
   // flips true). Keeping it mounted-but-closed left searchItems stuck on the
@@ -201,6 +212,7 @@ let CombinedPlaylist = (props) => {
       setCount={setCount}
       combinedStatus={combinedStatus}
       scStatusById={scStatusById}
+      chordsById={chordsById}
       bottomInset={bottomInset}
       onOverrideBpm={onOverrideBpm}
     />

--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -1090,6 +1090,11 @@ let Playlist = (props) => {
                         ? props.scStatusById[item.track.id]
                         : undefined
                     }
+                    chords={
+                      props.chordsById
+                        ? props.chordsById[item.track.id]
+                        : undefined
+                    }
                   />
                 ))}
             </TableBody>

--- a/client/src/components/PLLibrary/Row.jsx
+++ b/client/src/components/PLLibrary/Row.jsx
@@ -5,8 +5,10 @@ import {
   TableRow,
   IconButton,
   CircularProgress,
+  Tooltip,
 } from "@material-ui/core";
 import PlaylistAddIcon from "@material-ui/icons/PlaylistAdd";
+import MusicNoteIcon from "@material-ui/icons/MusicNote";
 
 import KeyMap from "../../utils/KeyMap";
 import { camelotColor, harmonicRelation } from "../../utils/harmonic";
@@ -225,19 +227,28 @@ let Row = (props) => {
       )}
       <TableCell>
         {keyInfo ? (
-          props.scStatus === "preview" ? (
-            <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-              {keyChip(keyLabel)}
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+            {keyChip(keyLabel)}
+            {props.scStatus === "preview" && (
               <span
                 title="Approximate — analyzed from a 30s SoundCloud preview"
                 style={{ color: "#ff5500", fontWeight: 700 }}
               >
                 ~
               </span>
-            </span>
-          ) : (
-            keyChip(keyLabel)
-          )
+            )}
+            {props.chords && props.chords.length > 0 && (
+              <Tooltip
+                arrow
+                enterTouchDelay={0}
+                title={`Chords (est.): ${props.chords.join(" → ")}`}
+              >
+                <MusicNoteIcon
+                  style={{ fontSize: 15, color: "#9aa0a6", cursor: "help" }}
+                />
+              </Tooltip>
+            )}
+          </span>
         ) : props.scStatus === "loading" ? (
           <span
             style={{

--- a/client/src/utils/scAnalysis.js
+++ b/client/src/utils/scAnalysis.js
@@ -20,7 +20,8 @@ import {
 // changes (so old/worse results get recomputed).
 //   v2: BPM detection moved from bpm-tools to madmom (band-constrained,
 //       genre-aware) — far better tempo octave resolution, so re-analyze.
-const ENGINE_VERSION = 2;
+//   v3: added chord-loop detection (madmom) — recompute to backfill `chords`.
+const ENGINE_VERSION = 3;
 
 // Firestore doc ids can't contain "/" — urns look like "soundcloud:tracks:123".
 const keyId = (urn) => String(urn).replace(/[:/]/g, "_");


### PR DESCRIPTION
Detects the **repeating chord loop** ("the N chords of this song, in order") for SoundCloud tracks and shows it in the now-playing + a per-row reveal. Signed off: now-playing + per-row reveal, recompute now.

### Analysis service (reuses the madmom already bundled for BPM — **no new dependency**)
- **`chords_madmom.py`** — madmom CNN chord features + CRF recognition → collapse the timeline → keep the core chords (~85% coverage) → reconstruct the cyclic order from the most-common chord-to-chord transitions (robust to a stray passing chord) → rotate to the keyfinder tonic + spell to the key. Prints a JSON array or `null` (no clear loop on busy/percussive tracks). majmin vocabulary.
- **`analyze.js`** — `detectChords` runs alongside key/BPM (kicks off once key resolves, for the rotation) and adds `chords` to the result. Backend is a pass-through, so no backend change.

### Frontend
- `scAnalysis` **ENGINE_VERSION 2→3** to backfill `chords` on recompute.
- **CurrentSong** — `Chords (est.): D♭ → A♭ → E♭ → B♭m` in the SoundCloud now-playing.
- **CombinedPlaylist** builds `chordsById`; **Playlist→Row** show a small ♪ icon with a tooltip of the loop in the Key cell (SoundCloud rows only). Spotify untouched.

### Notes
- Validated locally: *That's Where I'll Run* → `Db → Ab → Eb → Bbm` (your confirmed loop); 12/14 of THIS-IS-MYNN came back clean in testing.
- **SoundCloud-only**, **estimate**, **majmin**, **melodic-only** (busy tracks show nothing). Cyclic order reliable; starting chord is best-guess (anchored to the detected key).

### ⚠️ Deploy order (same as the BPM rollout)
1. Deploy the **analysis-service** first (subtree-split → `heroku-analysis`) — adds `chords`, additive/low-risk.
2. *Then* merge this PR → Netlify auto-deploys the frontend (ENGINE_VERSION=3) → recompute backfills chords as you open crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)