### PR TITLE
fix: bump ENGINE_VERSION to 4 (backfill chord-less v3 analyses)

### DIFF
--- a/client/src/utils/scAnalysis.js
+++ b/client/src/utils/scAnalysis.js
@@ -21,7 +21,10 @@ import {
 //   v2: BPM detection moved from bpm-tools to madmom (band-constrained,
 //       genre-aware) — far better tempo octave resolution, so re-analyze.
 //   v3: added chord-loop detection (madmom) — recompute to backfill `chords`.
-const ENGINE_VERSION = 3;
+//   v4: some v3 docs were written (in a pre-deploy test window) before the
+//       chord analysis-service was live, so they're "v3 but chord-less" and
+//       cache-stuck — re-analyze through the now-live chord service.
+const ENGINE_VERSION = 4;
 
 // Firestore doc ids can't contain "/" — urns look like "soundcloud:tracks:123".
 const keyId = (urn) => String(urn).replace(/[:/]/g, "_");


### PR DESCRIPTION
**Why chords weren't showing.** Some SoundCloud tracks have **v3 analysis docs with no `chords` field** — they were analyzed in a pre-deploy window (a v3 frontend hitting a non-chord analysis service) *before* the chord container (v9) went live. They're "valid v3" so they cache-hit and never re-analyze.

The deployed analysis service is verified correct (returns `chords`), so the fix is just to invalidate those stale docs: **ENGINE_VERSION 3 → 4** forces a clean re-analysis through the live chord service. Tracks already analyzed correctly re-run once; no behavior change otherwise.

After merge + deploy, re-open a crate **on the deployed app** → tracks re-analyze → the ♪ chord reveal appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)