### PR TITLE
feat: Spotify chord loops (chroma, client-side) — stage 1

### DIFF
--- a/client/src/components/PLLibrary/Playlist.jsx
+++ b/client/src/components/PLLibrary/Playlist.jsx
@@ -45,6 +45,7 @@ import Row from "./Row";
 import Recommendations from "./Recommendations";
 import KeyFilterPicker from "./KeyFilterPicker";
 import CrateDNA from "./CrateDNA";
+import { useSpotifyChords } from "../../utils/useSpotifyChords";
 
 initializeApp(firebaseConfig);
 
@@ -270,6 +271,10 @@ let Playlist = (props) => {
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const isTablet = useMediaQuery(theme.breakpoints.down("md"));
   const allItems = props.playlist;
+
+  // Spotify chord loops (computed client-side from /audio-analysis, cached).
+  // SoundCloud chords come from props.chordsById; Spotify ones from here.
+  const spotifyChordsById = useSpotifyChords(allItems, props.token);
 
   const [search, setSearch] = React.useState("");
   const [wheel, setWheel] = React.useState("Musical");
@@ -1091,9 +1096,8 @@ let Playlist = (props) => {
                         : undefined
                     }
                     chords={
-                      props.chordsById
-                        ? props.chordsById[item.track.id]
-                        : undefined
+                      (props.chordsById && props.chordsById[item.track.id]) ||
+                      spotifyChordsById[item.track.id]
                     }
                   />
                 ))}

--- a/client/src/utils/spotifyChordStore.js
+++ b/client/src/utils/spotifyChordStore.js
@@ -1,0 +1,53 @@
+import {
+  getFirestore,
+  doc,
+  setDoc,
+  collection,
+  getDocs,
+  query,
+  where,
+  documentId,
+} from "firebase/firestore";
+
+// Shared (cross-device) cache of computed Spotify chord loops, keyed by Spotify
+// track id. Like scAnalysis but for Spotify: a track's chords are computed once
+// — from /audio-analysis chroma client-side — and reused everywhere, so we never
+// re-hit Spotify for them. `chords: null` is cached too (a track with no clear
+// loop, or one audio-analysis can't serve) so we don't keep retrying it.
+const SP_CHORD_VERSION = 1;
+
+export async function getSpotifyChordsBulk(ids) {
+  const out = {};
+  const uniq = [...new Set((ids || []).filter(Boolean))];
+  if (!uniq.length) return out;
+  try {
+    const col = collection(getFirestore(), "spotifyChords");
+    const chunks = [];
+    for (let i = 0; i < uniq.length; i += 30) chunks.push(uniq.slice(i, i + 30));
+    const snaps = await Promise.all(
+      chunks.map((c) => getDocs(query(col, where(documentId(), "in", c))))
+    );
+    snaps.forEach((snap) =>
+      snap.forEach((d) => {
+        const x = d.data();
+        if (x && x.version === SP_CHORD_VERSION) out[d.id] = x;
+      })
+    );
+  } catch (e) {
+    // offline / rules / not-initialized → just skip the cache
+  }
+  return out;
+}
+
+export async function saveSpotifyChords(id, chords, source) {
+  try {
+    await setDoc(doc(getFirestore(), "spotifyChords", id), {
+      chords: chords && chords.length ? chords : null,
+      source: source || "chroma",
+      version: SP_CHORD_VERSION,
+      computedAt: Date.now(),
+    });
+  } catch (e) {
+    console.error("saveSpotifyChords failed", e);
+  }
+}

--- a/client/src/utils/spotifyChords.js
+++ b/client/src/utils/spotifyChords.js
@@ -1,0 +1,156 @@
+// Client-side chord-loop detection for SPOTIFY tracks from their /audio-analysis
+// chroma — no analysis service involved. Each segment carries a 12-dim pitch
+// (chroma) vector; we template-match it to a maj/min triad, collapse to a chord
+// timeline, extract the repeating loop, and rotate it to start on the FIRST
+// loop-chord that actually sounds (empirical, never assume the tonic). Spelled
+// to the track's key. Returns an array like ["Em","A","D","Bm"], or null when
+// there's no clear loop. This is the lighter, automatic path for Spotify;
+// madmom (preview) is the heavier on-demand fallback.
+
+const SHARP = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+const FLAT = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"];
+
+// 24 unit-norm triad templates.
+const TRIADS = [];
+for (let r = 0; r < 12; r++) {
+  for (const [isMin, ints] of [
+    [false, [0, 4, 7]],
+    [true, [0, 3, 7]],
+  ]) {
+    const v = new Array(12).fill(0);
+    for (const i of ints) v[(r + i) % 12] = 1;
+    const norm = Math.sqrt(3);
+    TRIADS.push({ root: r, min: isMin, vec: v.map((x) => x / norm) });
+  }
+}
+
+// `${root}-${min}` key helpers keep the maj/min distinction through the pipeline.
+const ck = (root, min) => `${root}-${min ? 1 : 0}`;
+
+function segChord(pitches) {
+  if (!pitches || pitches.length < 12) return null;
+  let n = 0;
+  for (let i = 0; i < 12; i++) n += pitches[i] * pitches[i];
+  n = Math.sqrt(n);
+  if (!n) return null;
+  let best = null;
+  let bestSim = -1;
+  for (const t of TRIADS) {
+    let s = 0;
+    for (let i = 0; i < 12; i++) s += (pitches[i] / n) * t.vec[i];
+    if (s > bestSim) {
+      bestSim = s;
+      best = t;
+    }
+  }
+  return best;
+}
+
+function collapse(segments, minDur = 0.8) {
+  const runs = [];
+  for (const s of segments) {
+    const t = segChord(s.pitches);
+    if (!t) continue;
+    const last = runs[runs.length - 1];
+    if (last && last.root === t.root && last.min === t.min) last.dur += s.duration;
+    else runs.push({ root: t.root, min: t.min, dur: s.duration });
+  }
+  return runs.filter((r) => r.dur >= minDur);
+}
+
+function mostCommon(arr) {
+  const c = {};
+  let best = arr[0];
+  let bn = 0;
+  for (const x of arr) {
+    c[x] = (c[x] || 0) + 1;
+    if (c[x] > bn) {
+      bn = c[x];
+      best = x;
+    }
+  }
+  return best;
+}
+
+function extractLoop(runs) {
+  if (!runs.length) return null;
+  // Core chords by total time (cover ~85%, cap 6).
+  const dur = {};
+  let total = 0;
+  for (const r of runs) {
+    const k = ck(r.root, r.min);
+    dur[k] = (dur[k] || 0) + r.dur;
+    total += r.dur;
+  }
+  const sorted = Object.entries(dur).sort((a, b) => b[1] - a[1]);
+  const core = [];
+  let cum = 0;
+  for (const [k, d] of sorted) {
+    core.push(k);
+    cum += d;
+    if (cum / total >= 0.85 || core.length >= 6) break;
+  }
+  if (core.length > 5) return null;
+  const coreSet = new Set(core);
+  // Dedup'd chronological sequence of core chords.
+  const seq = [];
+  for (const r of runs) {
+    const k = ck(r.root, r.min);
+    if (coreSet.has(k) && seq[seq.length - 1] !== k) seq.push(k);
+  }
+  if (!seq.length) return null;
+  // Reconstruct the cycle by following the most common successor.
+  const trans = {};
+  for (let i = 0; i < seq.length - 1; i++) {
+    const t = `${seq[i]}>${seq[i + 1]}`;
+    trans[t] = (trans[t] || 0) + 1;
+  }
+  let cur = mostCommon(seq);
+  const cyc = [cur];
+  while (cyc.length < coreSet.size) {
+    let next = null;
+    let nb = -1;
+    for (const k of coreSet) {
+      if (cyc.includes(k)) continue;
+      const c = trans[`${cur}>${k}`] || 0;
+      if (c > nb) {
+        nb = c;
+        next = k;
+      }
+    }
+    if (next === null) break;
+    cyc.push(next);
+    cur = next;
+  }
+  // Chronological-first: rotate so the loop starts on the first core chord that
+  // actually sounds (the collapse step already dropped sub-0.8s intro stabs).
+  const first = seq[0];
+  const i = cyc.indexOf(first);
+  return i > 0 ? cyc.slice(i).concat(cyc.slice(0, i)) : cyc;
+}
+
+// Should this key be spelled with flats? (flat-side of the Camelot wheel)
+const FLAT_KEYS = new Set([
+  "1-1", "8-1", "3-1", "10-1", "5-1", "6-1", // Db Ab Eb Bb F Gb major
+  "5-0", "0-0", "7-0", "2-0", "10-0", "3-0", // Fm Cm Gm Dm Bbm Ebm minor
+]);
+
+// Given Spotify's /audio-analysis JSON, return the chord loop or null.
+export function chordsFromAnalysis(analysis) {
+  try {
+    const segs = analysis && analysis.segments;
+    if (!Array.isArray(segs) || !segs.length) return null;
+    const cyc = extractLoop(collapse(segs));
+    if (!cyc || !cyc.length) return null;
+    const key = analysis.track ? analysis.track.key : -1;
+    const mode = analysis.track ? analysis.track.mode : 1;
+    const flats = key >= 0 && FLAT_KEYS.has(`${key}-${mode}`);
+    const names = flats ? FLAT : SHARP;
+    return cyc.map((k) => {
+      const [root, min] = k.split("-");
+      return names[Number(root)] + (min === "1" ? "m" : "");
+    });
+  } catch (e) {
+    return null;
+  }
+}

--- a/client/src/utils/useSpotifyChords.js
+++ b/client/src/utils/useSpotifyChords.js
@@ -1,0 +1,100 @@
+import React from "react";
+import { getSpotifyChordsBulk, saveSpotifyChords } from "./spotifyChordStore";
+import { chordsFromAnalysis } from "./spotifyChords";
+import { breakerWaitMs, note429, noteSuccess, throttleSlot } from "./spotifyLimiter";
+
+// Chord loops for the Spotify tracks in a view. Bulk-reads the shared cache up
+// front, then computes the MISSES one at a time from /audio-analysis — paced by
+// the same throttle + circuit breaker as the rest of our Spotify calls so it
+// can't stampede the rate limit — and caches each result (cross-device). Pure
+// client-side: no analysis service, no Eco dyno. Returns { [trackId]: chords }.
+export function useSpotifyChords(items, token) {
+  const [chordsById, setChordsById] = React.useState({});
+  const seenRef = React.useRef(new Set()); // ids already cached/queued
+  const queueRef = React.useRef([]);
+  const processingRef = React.useRef(false);
+
+  // Spotify track ids only (skip SoundCloud rows in the combined view).
+  const ids = React.useMemo(
+    () =>
+      (items || [])
+        .filter((it) => it && it.track && it.track.id && it.__source !== "soundcloud")
+        .map((it) => it.track.id),
+    [items]
+  );
+
+  const fetchAnalysis = React.useCallback(
+    async (id) => {
+      const wait = breakerWaitMs();
+      if (wait) await new Promise((r) => setTimeout(r, wait));
+      await throttleSlot();
+      const res = await fetch(`https://api.spotify.com/v1/audio-analysis/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.status === 429) {
+        note429();
+        const e = new Error("429");
+        e.retry = true;
+        throw e;
+      }
+      if (!res.ok) throw new Error("http " + res.status); // terminal (e.g. 403/404)
+      noteSuccess();
+      return res.json();
+    },
+    [token]
+  );
+
+  const processQueue = React.useCallback(() => {
+    if (processingRef.current) return;
+    processingRef.current = true;
+    (async () => {
+      while (queueRef.current.length) {
+        const id = queueRef.current.shift();
+        try {
+          const chords = chordsFromAnalysis(await fetchAnalysis(id));
+          saveSpotifyChords(id, chords, "chroma"); // caches null too (no re-try)
+          if (chords) setChordsById((m) => ({ ...m, [id]: chords }));
+        } catch (e) {
+          if (e && e.retry) {
+            // rate-limited → let it be re-queued on a later pass, and pause
+            seenRef.current.delete(id);
+            await new Promise((r) => setTimeout(r, 1200));
+          }
+          // terminal errors fall through: no chords, not re-queued
+        }
+      }
+      processingRef.current = false;
+    })();
+  }, [fetchAnalysis]);
+
+  React.useEffect(() => {
+    if (!token || !ids.length) return;
+    let cancelled = false;
+    (async () => {
+      const fresh = ids.filter((id) => !seenRef.current.has(id));
+      fresh.forEach((id) => seenRef.current.add(id));
+      if (!fresh.length) return;
+      const cached = await getSpotifyChordsBulk(fresh); // parallel bulk read
+      if (cancelled) return;
+      const hits = {};
+      const misses = [];
+      fresh.forEach((id) => {
+        if (cached[id]) {
+          if (cached[id].chords) hits[id] = cached[id].chords;
+        } else {
+          misses.push(id);
+        }
+      });
+      if (Object.keys(hits).length) setChordsById((m) => ({ ...m, ...hits }));
+      if (misses.length) {
+        misses.forEach((id) => queueRef.current.push(id));
+        processQueue();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [ids, token, processQueue]);
+
+  return chordsById;
+}


### PR DESCRIPTION
**Stage 1 of Spotify chord detection.** Computes a Spotify track's repeating chord loop **entirely client-side** from its `/audio-analysis` chroma — no analysis service, no Eco dyno. The lighter, automatic path for Spotify (madmom-on-preview is the heavier on-demand fallback, a later stage).

### What's in it
- **`spotifyChords.js`** — template-match each segment's 12-dim chroma to a maj/min triad → collapse → extract the loop → **rotate to the first loop-chord that actually sounds** (chronological, never assume the tonic) → spell to the key. Unit-tested: `Em→A→D→Bm` stays Em-first, a rotated input becomes A-first.
- **`spotifyChordStore.js`** — cross-device **Firestore** cache keyed by Spotify track id (caches `null` too, so a no-loop track isn't retried).
- **`useSpotifyChords.js`** — bulk-reads the cache, then computes misses **one at a time through the existing Spotify throttle + circuit breaker**, so it can't stampede the rate limit. Each result cached.
- **`Playlist`** wires it in; SoundCloud chords still take precedence, Spotify ones fill the rest, shown by the same per-row **♪**.

### Heads-up
This adds one `/audio-analysis` call per Spotify track on first view (throttled + cached forever). Since you're **currently rate-limited**, let that clear before testing, or you'll just 429 the chord fetches.

### Still to come (separate PRs)
2. chronological-first start for the madmom (SoundCloud) path too
3. the click-the-key-pill editor (relative-first key override + full chord add/remove/reorder, cross-device, survives re-analysis, both sources)
4. on-demand madmom for Spotify ("deep-analyze")

🤖 Generated with [Claude Code](https://claude.com/claude-code)